### PR TITLE
Header style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 html, body, #root {
     height: 100%;
+    margin: 0 -1px;
 }
 

--- a/src/components/header/ChangeLanguageButton.tsx
+++ b/src/components/header/ChangeLanguageButton.tsx
@@ -1,7 +1,6 @@
 import {IconButton, Menu, MenuItem} from "@mui/material";
 import LanguageIcon from '@mui/icons-material/Language';
 import React from "react";
-import { common } from '@mui/material/colors';
 import { availableLanguages, changeLanguage, InternalizationLanguage } from "../../language";
 
 export const ChangeLanguageButton = () => {
@@ -23,7 +22,7 @@ export const ChangeLanguageButton = () => {
     
     return <>
     <IconButton onClick={handleIconClick}>
-        <LanguageIcon sx={{ color: common.white }}/>
+        <LanguageIcon sx={{ color: 'GrayText'}}/>
     </IconButton>
 
     <Menu

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,15 +2,15 @@ import { AppBar, Grid } from "@mui/material";
 import {ReactComponent as PBLogo} from "./pblogo-whiteborder.svg"
 import { useTranslation } from 'react-i18next';
 import { ChangeLanguageButton } from "./ChangeLanguageButton";
+import styles from './header.module.css';
 
 export const Header = () => {
     const { t } = useTranslation("header");
     
-    
-    return <AppBar position="fixed">
-            <Grid container justifyContent="space-between">
-                <PBLogo height="50px"/>
-                <p align-content="center">{t('tool')}</p>
+    return <AppBar position="fixed" elevation={0}>
+            <Grid container className={styles.header}>
+                <PBLogo className={styles.logo}/>
+                <p className={styles.headerTitle}>{t('tool')}</p>
                 <ChangeLanguageButton/>
             </Grid>
         </AppBar>

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -1,0 +1,17 @@
+.header {
+    height: 48px;
+    background-color: #f8f8f8;
+    padding: 0 16px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+    justify-content: space-between;
+}
+
+.logo {
+    padding-top: 8px;
+    height: 100%;
+}
+
+.headerTitle{
+    color: #787878;
+    align-content: center;
+}

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -15,3 +15,9 @@
     color: #787878;
     align-content: center;
 }
+
+@media (max-width: 600px) {
+    .headerTitle {
+        display: none;
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1246

![imagen](https://user-images.githubusercontent.com/48812037/222756002-e631fa5f-2b70-49fd-82fd-02c88508b3e2.png)

Con el tema del scroll (que el header baje junto con el resto al scrollear), con Dany estuvimos viendo y no pareciera poder resolverse con css; por ahora lo mejor sería dejarlo como esta, total únicamente pasaría en la pantalla de desafíos y no molesta.

En pantallas chicas:

![imagen](https://user-images.githubusercontent.com/48812037/222761237-191b2c88-439a-454a-bdb4-f0a4ecd3b436.png)
