### PR TITLE
Testing all main components from App routes

### DIFF
--- a/src/components/creator/Selection.tsx
+++ b/src/components/creator/Selection.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, DialogContent, Stack, Typography } from "@mui/material"
+import { Button, Dialog, DialogContent, Stack } from "@mui/material"
 import { Header } from "../header/Header"
 import { useState } from "react"
 import { Link } from "react-router-dom"

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,7 +2,6 @@ import { AppBar, Grid } from "@mui/material";
 import {ReactComponent as PBLogo} from "../../assets/pblogo-whiteborder.svg"
 import { ChangeLanguageButton } from "./ChangeLanguageButton";
 import styles from './header.module.css';
-import theme from '../../theme';
 import { SessionButton } from "./login/SessionButton";
 import { Link } from "react-router-dom";
 

--- a/src/test/MainRoutesComponents.test.tsx
+++ b/src/test/MainRoutesComponents.test.tsx
@@ -1,0 +1,49 @@
+import { About } from "../components/About"
+import { BookView } from "../components/book/BookView"
+import { ChallengeById, ChallengeByName } from "../components/ChallengeView"
+import { CreatorEditor } from "../components/creator/Editor"
+import { CreatorSelection } from "../components/creator/Selection"
+import { Home } from "../components/home/Home"
+import { ImportedChallengeView } from "../components/ImportedChallengeView"
+import { PasswordRecovery } from "../components/PasswordRecovery"
+import { Register } from "../components/Register"
+import { renderComponent } from "./testUtils"
+import { validChallenge } from "./serializedChallenge.test"
+test('Renders home without errors', async () => {
+  renderComponent(<Home />)
+})
+test('Renders a challenge without errors', async () => {
+  renderComponent(<ChallengeById/>, ':id', '1')
+})
+
+test('Renders the book challenge list without errors', async () => {
+  renderComponent(<BookView/>, ':id', '1')
+})
+
+test('Renders challenge by name without errors', async () => {
+  renderComponent(<ChallengeByName />, ':challengeName', 'NoMeCansoDeSaltar')
+})
+
+test('Renders imported challenge without errors', async () => {
+  renderComponent(<ImportedChallengeView/>, '', '', [{state: validChallenge}])
+})
+
+test('Renders about route without errors', async () => {
+  renderComponent(<About/>)
+})
+
+test('Renders password-recovery route without errors', async () => {
+  renderComponent(<PasswordRecovery/>)
+})
+
+test('Renders register route without errors', async () => {
+  renderComponent(<Register/>)
+})
+
+test('Renders /creador/seleccionar route without errors', async () => {
+  renderComponent(<CreatorSelection/>)
+})
+
+test('Renders /creador/editar route without errors', async () => {
+  renderComponent(<CreatorEditor/>)
+})

--- a/src/test/MainRoutesComponents.test.tsx
+++ b/src/test/MainRoutesComponents.test.tsx
@@ -28,15 +28,15 @@ test('Renders imported challenge without errors', async () => {
   renderComponent(<ImportedChallengeView/>, '', '', [{state: validChallenge}])
 })
 
-test('Renders about route without errors', async () => {
+test('Renders about without errors', async () => {
   renderComponent(<About/>)
 })
 
-test('Renders password-recovery route without errors', async () => {
+test('Renders password-recovery without errors', async () => {
   renderComponent(<PasswordRecovery/>)
 })
 
-test('Renders register route without errors', async () => {
+test('Renders register without errors', async () => {
   renderComponent(<Register/>)
 })
 

--- a/src/test/MainRoutesComponents.test.tsx
+++ b/src/test/MainRoutesComponents.test.tsx
@@ -10,18 +10,20 @@ import { Register } from "../components/Register"
 import { renderComponent } from "./testUtils"
 import { validChallenge } from "./serializedChallenge.test"
 test('Renders home without errors', async () => {
-  renderComponent(<Home />)
+  await expect(
+    () => renderComponent(<Home />)
+  ).not.toThrowError();
 })
 test('Renders a challenge without errors', async () => {
-  renderComponent(<ChallengeById/>, ':id', '1')
+  renderComponent(<ChallengeById/>, '/desafio/:id', '1')
 })
 
 test('Renders the book challenge list without errors', async () => {
-  renderComponent(<BookView/>, ':id', '1')
+  renderComponent(<BookView/>, '/libros/:id', '1')
 })
 
 test('Renders challenge by name without errors', async () => {
-  renderComponent(<ChallengeByName />, ':challengeName', 'NoMeCansoDeSaltar')
+  renderComponent(<ChallengeByName />, '/desafios/:challengeName', 'NoMeCansoDeSaltar')
 })
 
 test('Renders imported challenge without errors', async () => {

--- a/src/test/MainRoutesComponents.test.tsx
+++ b/src/test/MainRoutesComponents.test.tsx
@@ -10,42 +10,40 @@ import { Register } from "../components/Register"
 import { renderComponent } from "./testUtils"
 import { validChallenge } from "./serializedChallenge.test"
 test('Renders home without errors', async () => {
-  await expect(
-    () => renderComponent(<Home />)
-  ).not.toThrowError();
+  expect(() => renderComponent(<Home />)).not.toThrowError()
 })
 test('Renders a challenge without errors', async () => {
-  renderComponent(<ChallengeById/>, '/desafio/:id', '1')
+  expect(() => renderComponent(<ChallengeById/>, '/desafio/:id', '1')).not.toThrowError()
 })
 
 test('Renders the book challenge list without errors', async () => {
-  renderComponent(<BookView/>, '/libros/:id', '1')
+  expect(() => renderComponent(<BookView/>, '/libros/:id', '1')).not.toThrowError()
 })
 
 test('Renders challenge by name without errors', async () => {
-  renderComponent(<ChallengeByName />, '/desafios/:challengeName', 'NoMeCansoDeSaltar')
+  expect(() => renderComponent(<ChallengeByName />, '/desafios/:challengeName', 'NoMeCansoDeSaltar')).not.toThrowError()
 })
 
 test('Renders imported challenge without errors', async () => {
-  renderComponent(<ImportedChallengeView/>, '', '', [{state: validChallenge}])
+  expect(() => renderComponent(<ImportedChallengeView/>, '', '', [{state: validChallenge}])).not.toThrowError()
 })
 
 test('Renders about without errors', async () => {
-  renderComponent(<About/>)
+  expect(() => renderComponent(<About/>)).not.toThrowError()
 })
 
 test('Renders password-recovery without errors', async () => {
-  renderComponent(<PasswordRecovery/>)
+  expect(() => renderComponent(<PasswordRecovery/>)).not.toThrowError()
 })
 
 test('Renders register without errors', async () => {
-  renderComponent(<Register/>)
+  expect(() => renderComponent(<Register/>)).not.toThrowError()
 })
 
 test('Renders /creador/seleccionar route without errors', async () => {
-  renderComponent(<CreatorSelection/>)
+  expect(() => renderComponent(<CreatorSelection/>)).not.toThrowError()
 })
 
 test('Renders /creador/editar route without errors', async () => {
-  renderComponent(<CreatorEditor/>)
+  expect(() => renderComponent(<CreatorEditor/>)).not.toThrowError()
 })

--- a/src/test/serializedChallenge.test.ts
+++ b/src/test/serializedChallenge.test.ts
@@ -63,21 +63,21 @@ describe('Scene validity', () => {
     })
 })
 
-describe('serialized challenge validity', () => {
-    const validChallenge: SerializedChallenge = {
-        fileVersion: 1,
-        title: "El ultimo desafio de Lita",
-        statement: {
-            description: "Va a poder lograrlo una ultima vez?",
-            clue: "Usa el poder secreto"
-        },
-        scene: validScene,
-        toolbox: {
-            blocks: ['Uno', 'Otro'],
-        },
-        stepByStep: true
-    }
+export const validChallenge: SerializedChallenge = {
+    fileVersion: 1,
+    title: "El ultimo desafio de Lita",
+    statement: {
+        description: "Va a poder lograrlo una ultima vez?",
+        clue: "Usa el poder secreto"
+    },
+    scene: validScene,
+    toolbox: {
+        blocks: ['Uno', 'Otro'],
+    },
+    stepByStep: true
+}
 
+describe('serialized challenge validity', () => {
 
     test('Valid challenge with valid scene is valid', () => {
         expect(isValidChallenge(validChallenge)).toBeTruthy()

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -20,7 +20,7 @@ export const renderComponent = (
     otherEntries: any[] = []) => {
   const basePath = routePath.split(":")[0]
   render(
-    <MemoryRouter initialEntries={[basePath + "/" + param].concat(otherEntries)}>
+    <MemoryRouter initialEntries={[basePath + param].concat(otherEntries)}>
         <Routes>
           <Route path={routePath}
             element = {

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -1,9 +1,33 @@
 import { render } from "@testing-library/react";
 import { ReactElement } from "react";
 import { I18nextProvider } from "react-i18next";
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import i18n from "../i18n";
 
-export const renderComponent = (component: ReactElement) => {
-  render(<BrowserRouter><I18nextProvider i18n={i18n}>{component}</I18nextProvider></BrowserRouter>)
+/**
+ * Renders a component for testing purposes.
+ * Provides i18n and route dynamic params if routePath and param are given.
+ * Provides additional entries
+ * @param component The component to render
+ * @param routePath Route with dynamic param with colon, e.g. "posts/:id"
+ * @param param e.g. "8" (meaning post with id 8)
+ * @param entries e.g. `{state: {userName='John'}}`
+ */
+export const renderComponent = (
+    component: ReactElement, 
+    routePath: string = '', 
+    param: string = '',
+    otherEntries: any[] = []) => {
+  const basePath = routePath.split(":")[0]
+  render(
+    <MemoryRouter initialEntries={[basePath + "/" + param].concat(otherEntries)}>
+        <Routes>
+          <Route path={routePath}
+            element = {
+              <I18nextProvider i18n={i18n}>
+              {component}
+              </I18nextProvider>
+            } />
+        </Routes>
+    </MemoryRouter>)
 }


### PR DESCRIPTION
Eso que dice el título. Me dí cuenta al meter errores varios en la app que los tests **seguían dando verde**.
Así que por ahora hice un parche, básicamente testeando un render pavo de todos los componentes principales de todas las rutas.

Para ello, tuve que toquetear la función `renderComponent` para que me dejara dar otra info de contexto (no solo i18n), como el location state o el valor de los parámetros dinámicos de la URL.

Quise hacer tests más de integración (renderizando `App` en lugar de los componentes, pero cambiando la ruta nada más), y lo logré, pero tenía el problema de que los errores saltaban en consola pero los tests seguían dando verde, así que la forma que encontré para que estallen los tests con errores de los componentes fue esta.

Abz