### PR TITLE
Traducción de home (ultra mini PR)

### DIFF
--- a/locales/en-us/home.json
+++ b/locales/en-us/home.json
@@ -10,5 +10,5 @@
 	"title": "Choose your level and start programming",
 	"signUp": "Sign up",
 	"importError": "The file is invalid",
-	"tool": "A tool to learn computer programming"
+	"header": "A tool to learn computer programming"
 }

--- a/locales/pt-br/header.json
+++ b/locales/pt-br/header.json
@@ -1,3 +1,0 @@
-{
-    "tool": "Uma ferramenta para aprender a programar"
-}

--- a/locales/pt-br/home.json
+++ b/locales/pt-br/home.json
@@ -1,0 +1,3 @@
+{
+    "header": "Uma ferramenta para aprender a programar"
+}


### PR DESCRIPTION
Había un detallín con la traducción del header de la home, no tenían el mismo nombre en los json de `en-us` y `pt-br` asi que siempre se mostraba en español por más que se cambiara el idioma.