### PR TITLE
Actor tool + context refactor part 2

### DIFF
--- a/src/components/creator/Editor/CreatorContext.tsx
+++ b/src/components/creator/Editor/CreatorContext.tsx
@@ -43,7 +43,7 @@ export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ childre
 
     useEffect(()=> {
         const challenge = LocalStorage.getCreatorChallenge()
-        challenge!.scene.maps[currentMap.index] = currentMap.map
+        challenge!.scene.maps[index] = map
         LocalStorage.saveCreatorChallenge(challenge)        
     }, [currentMap])
 

--- a/src/components/creator/Editor/CreatorContext.tsx
+++ b/src/components/creator/Editor/CreatorContext.tsx
@@ -42,8 +42,7 @@ export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ childre
     const index = currentMap.index
 
     useEffect(()=> {
-        const challenge = LocalStorage.getCreatorChallenge()
-        challenge!.scene.maps[index] = map
+        challenge!.scene.maps[currentMap.index] = currentMap.map
         LocalStorage.saveCreatorChallenge(challenge)        
     }, [currentMap])
 

--- a/src/components/creator/Editor/CreatorContext.tsx
+++ b/src/components/creator/Editor/CreatorContext.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { SceneMap, defaultChallenge } from '../../serializedChallenge';
 import { LocalStorage } from '../../../localStorage';
+import { Position } from './SceneEdition/Grid/SceneCell';
 
 export type CreatorContextType = {
     selectedTool: string;
     setSelectedTool: (selectedTool: string) => void;
     currentMap: CurrentMap;
-    changeMapAtCurrentIndex: (map: SceneMap) => void;
-    changeIndex: (index: number) => void;
+    setCurrentMap2: (map: SceneMap) => void;
+    setIndex: (index: number) => void;
 };
 
 const defaultCreatorContext = {
@@ -17,8 +18,8 @@ const defaultCreatorContext = {
         map: defaultChallenge("Duba").scene.maps[0],
         index: 0
     },
-    changeMapAtCurrentIndex: () => { },
-    changeIndex: () => { }
+    setCurrentMap2: () => { },
+    setIndex: () => { },
 }
 
 export const CreatorContext = React.createContext<CreatorContextType>(defaultCreatorContext);
@@ -38,10 +39,10 @@ export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ childre
 
     const challenge = LocalStorage.getCreatorChallenge() || defaultChallenge("Duba")
     const [currentMap, setCurrentMap] = useState({map: challenge!.scene.maps[0] , index: 0})
-    
-    const changeIndex = (newIndex: number) => setCurrentMap({...currentMap, index: newIndex})
 
-    const changeMapAtCurrentIndex = (newMap: SceneMap) => {
+    const setIndex = (newIndex: number) => setCurrentMap({...currentMap, index: newIndex})
+
+    const setCurrentMap2 = (newMap: SceneMap) => {
         setCurrentMap({...currentMap, map: newMap})
     }
 
@@ -52,7 +53,7 @@ export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ childre
     }, [currentMap])
 
     return (
-        <CreatorContext.Provider value={{ selectedTool, setSelectedTool, currentMap, changeMapAtCurrentIndex, changeIndex}}>
+        <CreatorContext.Provider value={{ selectedTool, setSelectedTool, currentMap, setCurrentMap2, setIndex}}>
             {children}
         </CreatorContext.Provider>
     );

--- a/src/components/creator/Editor/CreatorContext.tsx
+++ b/src/components/creator/Editor/CreatorContext.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { SceneMap, defaultChallenge } from '../../serializedChallenge';
 import { LocalStorage } from '../../../localStorage';
+import { ACTOR } from './SceneEdition/SceneEdition';
 
 export type CreatorContextType = {
     selectedTool: string;
@@ -27,7 +28,7 @@ export type CreatorProviderProps = {
     defaultSelectedTool?: string;
 };
 
-export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ children, defaultSelectedTool = '' }: CreatorProviderProps) => {
+export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ children, defaultSelectedTool = ACTOR }: CreatorProviderProps) => {
     const [selectedTool, setSelectedTool] = useState(defaultSelectedTool);
 
     const challenge = LocalStorage.getCreatorChallenge() || defaultChallenge("Duba")

--- a/src/components/creator/Editor/CreatorContext.tsx
+++ b/src/components/creator/Editor/CreatorContext.tsx
@@ -1,24 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import { SceneMap, defaultChallenge } from '../../serializedChallenge';
 import { LocalStorage } from '../../../localStorage';
-import { Position } from './SceneEdition/Grid/SceneCell';
 
 export type CreatorContextType = {
     selectedTool: string;
     setSelectedTool: (selectedTool: string) => void;
-    currentMap: CurrentMap;
-    setCurrentMap2: (map: SceneMap) => void;
+    map: SceneMap;
+    setMap: (map: SceneMap) => void;
+    index: number;
     setIndex: (index: number) => void;
 };
 
 const defaultCreatorContext = {
     selectedTool: '',
     setSelectedTool: () => { },
-    currentMap: {
-        map: defaultChallenge("Duba").scene.maps[0],
-        index: 0
-    },
-    setCurrentMap2: () => { },
+    map: defaultChallenge('Duba').scene.maps[0],
+    setMap: () => { },
+    index: 0, 
     setIndex: () => { },
 }
 
@@ -29,11 +27,6 @@ export type CreatorProviderProps = {
     defaultSelectedTool?: string;
 };
 
-type CurrentMap = {
-    map: SceneMap;
-    index: number;
-}
-
 export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ children, defaultSelectedTool = '' }: CreatorProviderProps) => {
     const [selectedTool, setSelectedTool] = useState(defaultSelectedTool);
 
@@ -42,9 +35,10 @@ export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ childre
 
     const setIndex = (newIndex: number) => setCurrentMap({...currentMap, index: newIndex})
 
-    const setCurrentMap2 = (newMap: SceneMap) => {
-        setCurrentMap({...currentMap, map: newMap})
-    }
+    const setMap = (newMap: SceneMap) => setCurrentMap({...currentMap, map: newMap})
+
+    const map = currentMap.map
+    const index = currentMap.index
 
     useEffect(()=> {
         const challenge = LocalStorage.getCreatorChallenge()
@@ -53,7 +47,7 @@ export const CreatorContextProvider: React.FC<CreatorProviderProps> = ({ childre
     }, [currentMap])
 
     return (
-        <CreatorContext.Provider value={{ selectedTool, setSelectedTool, currentMap, setCurrentMap2, setIndex}}>
+        <CreatorContext.Provider value={{ selectedTool, setSelectedTool, map, setMap, index, setIndex}}>
             {children}
         </CreatorContext.Provider>
     );

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
@@ -26,9 +26,9 @@ export const SceneCell: React.FC<CellProps> = (props) => {
 
     const objectStyle = (object: string) => styles[`img-${object}`] || styles['img-default']
 
-    const hasMultipleObjects: boolean = objectsInCell.length > 1
+    const hasMultipleObjects = (cellObjects = objectsInCell): boolean => cellObjects.length > 1
 
-    const cellHasActor: boolean = objectsInCell.includes(ACTOR)
+    const cellHasActor = (cell = props.content): boolean => cell.split('&').includes(ACTOR)
 
     const isInitialCell: boolean = props.position.row === INITIAL_ROW && props.position.column === INITIAL_COL
 
@@ -51,35 +51,34 @@ export const SceneCell: React.FC<CellProps> = (props) => {
 
     const deletedActorMap = () => {
         let prevPos = actorPosition()
-        let cell = map[prevPos.row][prevPos.column].split('&')
-        map[prevPos.row][prevPos.column] = cell.length > 1 ? cell[1] : EMPTY
+        let cellObjects = map[prevPos.row][prevPos.column].split('&')
+        map[prevPos.row][prevPos.column] = hasMultipleObjects(cellObjects) ? cellObjects[1] : EMPTY
         return map
     }
 
     const handleEraser = (): SceneMap => {
-        if (cellHasActor && isInitialCell && !hasMultipleObjects) return map; // We can't erase actor on the initial cell
-        if (cellHasActor && !hasMultipleObjects) map = setActorAtPosition(map)
-        return currentMapWithNewCellContent(hasMultipleObjects ? ACTOR : EMPTY)
+        if (cellHasActor() && isInitialCell && !hasMultipleObjects()) return map; // We can't erase actor on the initial cell
+        if (cellHasActor() && !hasMultipleObjects()) map = setActorAtPosition(map)
+        return mapWithNewCellContent(hasMultipleObjects() ? ACTOR : EMPTY)
     } 
 
     const handlePrize = (): SceneMap => {
-        return currentMapWithNewCellContent(cellHasActor ? ACTOR + '&' + selectedTool : selectedTool)
+        return mapWithNewCellContent(cellHasActor() ? ACTOR + '&' + selectedTool : selectedTool)
     }
 
     const handleObstacle = (): SceneMap => {
-        if (cellHasActor && isInitialCell) return map; // We can't replace actor on the initial cell
-        if (cellHasActor && !isInitialCell) map = setActorAtPosition(map)
-        return currentMapWithNewCellContent(selectedTool)
+        if (cellHasActor() && isInitialCell) return map; // We can't replace actor on the initial cell
+        if (cellHasActor() && !isInitialCell) map = setActorAtPosition(map)
+        return mapWithNewCellContent(selectedTool)
     } 
 
     const actorPosition = (): Position => {
-        const hasActor = (cell: string) => cell.split('&').includes(ACTOR)
-        let row = map.findIndex(row => row.some(hasActor))
-        let column = map[row].findIndex(hasActor)
+        let row = map.findIndex(row => row.some(cellHasActor))
+        let column = map[row].findIndex(cellHasActor)
         return { row, column }
     }
 
-    const currentMapWithNewCellContent = (content: string, position: Position = props.position): SceneMap => {
+    const mapWithNewCellContent = (content: string, position: Position = props.position): SceneMap => {
         map[position.row][position.column] = content
         return map
     }
@@ -87,7 +86,7 @@ export const SceneCell: React.FC<CellProps> = (props) => {
     return <div
         data-testid="challenge-cell"
         className={styles.cell}
-        style={{ backgroundImage: `url(${backgroundCellImage})`, justifyContent: !hasMultipleObjects ? 'center' : '' }}
+        style={{ backgroundImage: `url(${backgroundCellImage})`, justifyContent: !hasMultipleObjects() ? 'center' : '' }}
         onClick={handleClick}>
         {objectsInCell.map(obj =>
             <img

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
@@ -38,7 +38,6 @@ export const SceneCell: React.FC<CellProps> = (props) => {
 
     const updatedMap = (): SceneMap => {
         switch (selectedTool) {
-            case '': return map; //by context default
             case OBSTACLE: return handleObstacle();
             case EMPTY: return handleEraser();
             case ACTOR: return handleActor();

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
@@ -17,7 +17,7 @@ export type Position = {
 
 export const SceneCell: React.FC<CellProps> = (props) => {
 
-    const { selectedTool, currentMap, setCurrentMap2 } = useContext(CreatorContext)
+    let { selectedTool, map, setMap } = useContext(CreatorContext)
 
     const imagePath = `imagenes/sceneImages/${props.sceneType}`
     const backgroundCellImage = `${imagePath}/casilla.png`
@@ -33,12 +33,12 @@ export const SceneCell: React.FC<CellProps> = (props) => {
     const isInitialCell: boolean = props.position.row === INITIAL_ROW && props.position.column === INITIAL_COL
 
     const handleClick = () => {
-        setCurrentMap2(updatedMap())
+        setMap(updatedMap())
     }
 
     const updatedMap = (): SceneMap => {
         switch (selectedTool) {
-            case '': return currentMap.map; //by context default
+            case '': return map; //by context default
             case OBSTACLE: return handleObstacle();
             case EMPTY: return handleEraser();
             case ACTOR: return handleActor();
@@ -52,15 +52,14 @@ export const SceneCell: React.FC<CellProps> = (props) => {
 
     const deletedActorMap = () => {
         let prevPos = actorPosition()
-        let map = currentMap.map
         let cell = map[prevPos.row][prevPos.column].split('&')
         map[prevPos.row][prevPos.column] = cell.length > 1 ? cell[1] : EMPTY
         return map
     }
 
     const handleEraser = (): SceneMap => {
-        if (cellHasActor && isInitialCell && !hasMultipleObjects) return currentMap.map; // We can't erase actor on the initial cell
-        if (cellHasActor && !hasMultipleObjects) currentMap.map = setActorAtPosition(currentMap.map)
+        if (cellHasActor && isInitialCell && !hasMultipleObjects) return map; // We can't erase actor on the initial cell
+        if (cellHasActor && !hasMultipleObjects) map = setActorAtPosition(map)
         return currentMapWithNewCellContent(hasMultipleObjects ? ACTOR : EMPTY)
     } 
 
@@ -69,21 +68,21 @@ export const SceneCell: React.FC<CellProps> = (props) => {
     }
 
     const handleObstacle = (): SceneMap => {
-        if (cellHasActor && isInitialCell) return currentMap.map; // We can't replace actor on the initial cell
-        if (cellHasActor && !isInitialCell) currentMap.map = setActorAtPosition(currentMap.map)
+        if (cellHasActor && isInitialCell) return map; // We can't replace actor on the initial cell
+        if (cellHasActor && !isInitialCell) map = setActorAtPosition(map)
         return currentMapWithNewCellContent(selectedTool)
     } 
 
     const actorPosition = (): Position => {
         const hasActor = (cell: string) => cell.split('&').includes(ACTOR)
-        let row = currentMap.map.findIndex(row => row.some(hasActor))
-        let column = currentMap.map[row].findIndex(hasActor)
+        let row = map.findIndex(row => row.some(hasActor))
+        let column = map[row].findIndex(hasActor)
         return { row, column }
     }
 
     const currentMapWithNewCellContent = (content: string, position: Position = props.position): SceneMap => {
-        currentMap.map[position.row][position.column] = content
-        return currentMap.map
+        map[position.row][position.column] = content
+        return map
     }
 
     return <div

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneCell.tsx
@@ -1,5 +1,5 @@
 import styles from "./grid.module.css"
-import { useContext, useEffect, useState } from "react"
+import { useContext } from "react"
 import { CreatorContext } from "../../CreatorContext"
 import { ACTOR, INITIAL_ROW, INITIAL_COL, OBSTACLE, EMPTY, setActorAtPosition } from "../SceneEdition"
 import { SceneMap, SceneType } from "../../../../serializedChallenge"
@@ -28,7 +28,7 @@ export const SceneCell: React.FC<CellProps> = (props) => {
 
     const hasMultipleObjects = (cellObjects = objectsInCell): boolean => cellObjects.length > 1
 
-    const cellHasActor = (cell = props.content): boolean => cell.split('&').includes(ACTOR)
+    const hasActor = (cell = props.content): boolean => cell.split('&').includes(ACTOR)
 
     const isInitialCell: boolean = props.position.row === INITIAL_ROW && props.position.column === INITIAL_COL
 
@@ -57,24 +57,24 @@ export const SceneCell: React.FC<CellProps> = (props) => {
     }
 
     const handleEraser = (): SceneMap => {
-        if (cellHasActor() && isInitialCell && !hasMultipleObjects()) return map; // We can't erase actor on the initial cell
-        if (cellHasActor() && !hasMultipleObjects()) map = setActorAtPosition(map)
+        if (hasActor() && isInitialCell && !hasMultipleObjects()) return map; // We can't erase actor on the initial cell
+        if (hasActor() && !hasMultipleObjects()) map = setActorAtPosition(map)
         return mapWithNewCellContent(hasMultipleObjects() ? ACTOR : EMPTY)
     } 
 
     const handlePrize = (): SceneMap => {
-        return mapWithNewCellContent(cellHasActor() ? ACTOR + '&' + selectedTool : selectedTool)
+        return mapWithNewCellContent(hasActor() ? ACTOR + '&' + selectedTool : selectedTool)
     }
 
     const handleObstacle = (): SceneMap => {
-        if (cellHasActor() && isInitialCell) return map; // We can't replace actor on the initial cell
-        if (cellHasActor() && !isInitialCell) map = setActorAtPosition(map)
+        if (hasActor() && isInitialCell) return map; // We can't replace actor on the initial cell
+        if (hasActor() && !isInitialCell) map = setActorAtPosition(map)
         return mapWithNewCellContent(selectedTool)
     } 
 
     const actorPosition = (): Position => {
-        let row = map.findIndex(row => row.some(cellHasActor))
-        let column = map[row].findIndex(cellHasActor)
+        let row = map.findIndex(row => row.some(hasActor))
+        let column = map[row].findIndex(hasActor)
         return { row, column }
     }
 

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "@mui/material"
-import { SceneMap, SceneType, SerializedChallenge, defaultChallenge } from "../../../../serializedChallenge"
+import { SceneType, SerializedChallenge, defaultChallenge } from "../../../../serializedChallenge"
 import { LocalStorage } from "../../../../../localStorage"
 import styles from "./grid.module.css"
 import { SceneCell } from "./SceneCell"

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
@@ -9,7 +9,7 @@ import { CreatorContext } from "../../CreatorContext"
 
 export const SceneGrid = () => {
 
-    const { currentMap } = useContext(CreatorContext)
+    const { map } = useContext(CreatorContext)
 
     const storageChallenge = LocalStorage.getCreatorChallenge()
     const challenge: SerializedChallenge = storageChallenge ? storageChallenge : defaultChallenge('Duba')
@@ -17,7 +17,7 @@ export const SceneGrid = () => {
     const sceneType: SceneType = challenge.scene.type
 
     return <Stack className={styles.grid + ' ' + styles.border}>
-        {currentMap.map.map((row, i) =>
+        {map.map((row, i) =>
             <Stack key={i + row.join(',')} direction="row" data-testid="challenge-row">
                 {row.map((cellContent, j) =>
                     <SceneCell

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -29,7 +29,6 @@ export const setActorAtPosition = (inMap: SceneMap, row = INITIAL_ROW, col = INI
     return inMap;
 }
 
-
 export const relocateActor = (row: string[], colSearch: number, inMap: SceneMap) => {
     if (row.includes(ACTOR, colSearch)) {
         return setActorAtPosition(inMap)
@@ -45,17 +44,13 @@ type SizeProps = {
 const SizeEditor = (props: SizeProps) => {
     const { t } = useTranslation("creator")
 
-    let { map } = useContext(CreatorContext)
-
-    const initialRows = map.length
-    const initialColumns = map[INITIAL_ROW].length
-
-    const [rows, setRow] = useState(initialRows || 1)
-    const [columns, setCol] = useState(initialColumns || 1)
+    let { map, setMap } = useContext(CreatorContext)
 
     const rowsInMap = map.length
-
     const columnsInMap = map[INITIAL_ROW].length
+
+    const [rows, setRow] = useState(rowsInMap || 1)
+    const [columns, setCol] = useState(columnsInMap || 1)
 
     const updateRowsIfChanged = useCallback(() => {
         if (rows < rowsInMap) { //Row was removed
@@ -85,6 +80,7 @@ const SizeEditor = (props: SizeProps) => {
     useEffect(() => {
         updateRowsIfChanged()
         updateColumnsIfChanged()
+        setMap(map)
     }, [props, updateColumnsIfChanged, updateRowsIfChanged]);
 
 

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -45,10 +45,10 @@ type SizeProps = {
 const SizeEditor = (props: SizeProps) => {
     const { t } = useTranslation("creator")
 
-    const { currentMap } = useContext(CreatorContext)
+    const { map, index } = useContext(CreatorContext)
 
-    const initialRows = currentMap.map.length
-    const initialColumns = currentMap.map[INITIAL_ROW].length
+    const initialRows = map.length
+    const initialColumns = map[INITIAL_ROW].length
 
     const [rows, setRow] = useState(initialRows || 1)
     const [columns, setCol] = useState(initialColumns || 1)
@@ -85,7 +85,7 @@ const SizeEditor = (props: SizeProps) => {
     useEffect(() => {
 
         const challenge: SerializedChallenge = LocalStorage.getCreatorChallenge()!
-        const map: SceneMap = challenge.scene.maps[currentMap.index];
+        const map: SceneMap = challenge.scene.maps[index];
 
         updateRowsIfChanged(map)
         updateColumnsIfChanged(map)

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -16,11 +16,15 @@ export const EMPTY = "-"
 export const INITIAL_COL = 0
 export const INITIAL_ROW = 0
 
-export const setActorAtInitialPosition = (inMap: SceneMap) => {
-    if (inMap[INITIAL_ROW][INITIAL_COL] === EMPTY || inMap[INITIAL_ROW][INITIAL_COL] === OBSTACLE) {
-        inMap[INITIAL_ROW][INITIAL_COL] = ""
+/**
+ * If no position is given, the actor is set in the initial one (0,0)
+ * @returns a map with the actor in another position.
+ */
+export const setActorAtPosition = (inMap: SceneMap, row = INITIAL_ROW, col = INITIAL_COL) => {
+    if (inMap[row][col] === EMPTY || inMap[row][col] === OBSTACLE) {
+        inMap[row][col] = ""
     }
-    inMap[INITIAL_ROW][INITIAL_COL] = ACTOR + (inMap[INITIAL_ROW][INITIAL_COL].length ? '&' + inMap[INITIAL_ROW][INITIAL_COL] : '')
+    inMap[row][col] = ACTOR + (inMap[row][col].length ? '&' + inMap[row][col] : '')
 
     return inMap;
 }
@@ -28,7 +32,7 @@ export const setActorAtInitialPosition = (inMap: SceneMap) => {
 
 export const relocateActor = (row: string[], colSearch: number, inMap: SceneMap) => {
     if (row.includes(ACTOR, colSearch)) {
-        return setActorAtInitialPosition(inMap)
+        return setActorAtPosition(inMap)
     }
     return inMap;
 }

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -4,8 +4,7 @@ import { SceneTools } from "./SceneTools";
 import { useTranslation } from "react-i18next"
 import { IncDecButtons } from "./IncDecButtons";
 import { useState, useCallback, useEffect, useContext } from 'react';
-import { LocalStorage } from "../../../../localStorage";
-import { SceneMap, SerializedChallenge } from "../../../serializedChallenge";
+import { SceneMap } from "../../../serializedChallenge";
 import { CreatorContext } from "../CreatorContext";
 
 export const OBSTACLE = "O"

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -45,7 +45,7 @@ type SizeProps = {
 const SizeEditor = (props: SizeProps) => {
     const { t } = useTranslation("creator")
 
-    const { map, index } = useContext(CreatorContext)
+    let { map, index } = useContext(CreatorContext)
 
     const initialRows = map.length
     const initialColumns = map[INITIAL_ROW].length
@@ -53,45 +53,38 @@ const SizeEditor = (props: SizeProps) => {
     const [rows, setRow] = useState(initialRows || 1)
     const [columns, setCol] = useState(initialColumns || 1)
 
-    const rowsInMap = (currentMap: SceneMap): number => currentMap.length
+    const rowsInMap = map.length
 
-    const columnsInMap = (currentMap: SceneMap): number => currentMap[INITIAL_ROW].length
+    const columnsInMap = map[INITIAL_ROW].length
 
-    const updateRowsIfChanged = useCallback((currentMap: SceneMap) => {
-        if (rows < rowsInMap(currentMap)) { //Row was removed
-            currentMap = relocateActor(currentMap[currentMap.length - 1], INITIAL_COL, currentMap)
-            currentMap.pop()
+    const updateRowsIfChanged = useCallback(() => {
+        if (rows < rowsInMap) { //Row was removed
+            map = relocateActor(map[map.length - 1], INITIAL_COL, map)
+            map.pop()
         }
-        if (rows > rowsInMap(currentMap)) //Row was added
-            currentMap.push(currentMap[INITIAL_ROW].slice().fill(EMPTY))
+        if (rows > rowsInMap) //Row was added
+            map.push(map[INITIAL_ROW].slice().fill(EMPTY))
 
         props.setRows(rows)
     }, [props, rows])
 
-    const updateColumnsIfChanged = useCallback((currentMap: SceneMap) => {
-        if (columns < columnsInMap(currentMap)) { //Column was removed
-            currentMap.map((row) => {
-                currentMap = relocateActor(row, row.length - 1, currentMap)
+    const updateColumnsIfChanged = useCallback(() => {
+        if (columns < columnsInMap) { //Column was removed
+            map.map((row) => {
+                map = relocateActor(row, row.length - 1, map)
                 return row.pop()
             })
         }
-        if (columns > columnsInMap(currentMap)) //Column was added
-            currentMap.map((row, i) => currentMap[i] = row.concat(EMPTY))
+        if (columns > columnsInMap) //Column was added
+            map.map((row, i) => map[i] = row.concat(EMPTY))
 
         props.setColumns(columns)
 
     }, [columns, props])
 
     useEffect(() => {
-
-        const challenge: SerializedChallenge = LocalStorage.getCreatorChallenge()!
-        const map: SceneMap = challenge.scene.maps[index];
-
-        updateRowsIfChanged(map)
-        updateColumnsIfChanged(map)
-
-        LocalStorage.saveCreatorChallenge(challenge)
-
+        updateRowsIfChanged()
+        updateColumnsIfChanged()
     }, [props, updateColumnsIfChanged, updateRowsIfChanged]);
 
 

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -45,7 +45,7 @@ type SizeProps = {
 const SizeEditor = (props: SizeProps) => {
     const { t } = useTranslation("creator")
 
-    let { map, index } = useContext(CreatorContext)
+    let { map } = useContext(CreatorContext)
 
     const initialRows = map.length
     const initialColumns = map[INITIAL_ROW].length

--- a/src/test/SceneCell.test.tsx
+++ b/src/test/SceneCell.test.tsx
@@ -8,8 +8,6 @@ import { ACTOR, EMPTY, OBSTACLE } from '../components/creator/Editor/SceneEditio
 
 describe('Scene grid', () => {
 
-    let defChallange: SerializedChallenge
-
     const position: Position = {
         row: 0,
         column: 0

--- a/src/test/SceneCell.test.tsx
+++ b/src/test/SceneCell.test.tsx
@@ -132,7 +132,12 @@ describe('Scene grid', () => {
     test('Erase cell with actor, should relocate actor to initial cell', () => {
         expectContentAfterClick(EMPTY, 1, 0, EMPTY)
         expect(getContentFromLocalStorage(0, 0)).toBe(ACTOR)
+    })
 
+    test('Erase cell with actor and prize at initial cell, should relocate actor to initial cell and keep prize', () => {
+        saveChallange('Duba', [[["P", "O", "A"], ["-", "P", "-"]]])
+        expectContentAfterClick(EMPTY, 0, 2, EMPTY)
+        expect(getContentFromLocalStorage(0, 0)).toBe('A&P')
     })
 
     test('Erase cell with actor and prize, should only erase prize', () => {

--- a/src/test/SceneCell.test.tsx
+++ b/src/test/SceneCell.test.tsx
@@ -147,6 +147,30 @@ describe('Scene grid', () => {
         expectContentAfterClick(EMPTY, 0, 0, ACTOR)
     })
 
+    //ACTOR
+    test('Sets actor in cell, should delete it from previous position', () => {
+        expectContentAfterClick(ACTOR, 1, 2, ACTOR)
+        expect(getContentFromLocalStorage(1, 0)).toBe(EMPTY)
+    })
+
+    test('Sets actor in cell with prize, should keep both actor and prize', () => {
+        expectContentAfterClick(ACTOR, 1, 1, 'A&P')
+    })
+
+    test('Sets actor in cell with obstacle, should replace it', () => {
+        expectContentAfterClick(ACTOR, 0, 1, ACTOR)
+    })
+
+    test('Sets actor in empty cell', () => {
+        expectContentAfterClick(ACTOR, 0, 0, ACTOR)
+    })  
+
+    test('Sets actor in cell with previous actor in cell with prize, should not erase the prize', () => {
+        saveChallange('Duba', [[["-", "O", "A&P"], ["-", "P", "-"]]])
+        expectContentAfterClick(ACTOR, 0, 0, ACTOR)
+        expect(getContentFromLocalStorage(0, 2)).toBe('P')
+    })
+
 })
 
 

--- a/src/test/SceneEdition.test.tsx
+++ b/src/test/SceneEdition.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { defaultChallenge, SerializedChallenge } from "../components/serializedChallenge"
 import { SceneEdition } from '../components/creator/Editor/SceneEdition/SceneEdition';
 import { LocalStorage } from '../localStorage';
-import { renderComponent } from './testUtils';
+import { renderComponent, renderWithContext } from './testUtils';
 
 describe('Scene Edition', () => {
     afterEach(() => {
@@ -25,9 +25,9 @@ describe('Scene Edition', () => {
     }
 
     //TODO fix with rows and columns context refactor
-    test.skip("increment cols and rows to challenge map", async () => {
+    test("increment cols and rows to challenge map", async () => {
   
-        renderComponent(<SceneEdition />)
+        renderWithContext(<SceneEdition />)
 
         const incCols = await screen.findByTestId('inc-btn-col')
         const incRows = await screen.findByTestId('inc-btn-row')
@@ -39,9 +39,9 @@ describe('Scene Edition', () => {
         expect((await getGridSize()).columns).toBe(4)
     })
  
-    test.skip("decrement cols and rows to challenge map", async () => {
+    test("decrement cols and rows to challenge map", async () => {
   
-        renderComponent(<SceneEdition />)
+        renderWithContext(<SceneEdition />)
 
         const decCols = await screen.findByTestId('dec-btn-col')
         const decRows = await screen.findByTestId('dec-btn-row')
@@ -53,7 +53,7 @@ describe('Scene Edition', () => {
         expect((await getGridSize()).columns).toBe(2)
     })
 
-    test.skip("decrement a col and check if actor changes to [0,0] challenge map cell", async () => {
+    test("decrement a col and check if actor changes to [0,0] challenge map cell", async () => {
 
         let challenge: SerializedChallenge = {
             ...defaultChallenge("Duba"),
@@ -65,7 +65,7 @@ describe('Scene Edition', () => {
     
         LocalStorage.saveCreatorChallenge(challenge)
       
-        renderComponent(<SceneEdition />)
+        renderWithContext(<SceneEdition />)
 
         const decCols = await screen.findByTestId('dec-btn-col')
                 

--- a/src/test/SceneGrid.test.tsx
+++ b/src/test/SceneGrid.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { defaultChallenge } from '../components/serializedChallenge';
 import { LocalStorage } from '../localStorage';
 import { SceneGrid } from '../components/creator/Editor/SceneEdition/Grid/SceneGrid';
 import { SerializedChallenge } from '../components/serializedChallenge';
+import { renderWithContext } from './testUtils';
 
 describe('Scene grid', () => {
 
@@ -13,25 +14,25 @@ describe('Scene grid', () => {
         const rows = await getAmountFromChallenge('row')
         const columns = await getAmountFromChallenge('cell') / rows
 
-        return {rows, columns}
+        return { rows, columns }
     }
 
     afterEach(() => {
         localStorage.clear()
     })
 
-    test.skip('Should set grid size according to local storage', async () => {
+    test('Should set grid size according to local storage', async () => {
 
         const challenge: SerializedChallenge = {
             ...defaultChallenge("Duba"),
             scene: {
                 type: "Duba",
-                maps: [[["A","-","-","-","-"],["-","-","-","-","-"],["-","-","-","-","-"]]]
+                maps: [[["A", "-", "-", "-", "-"], ["-", "-", "-", "-", "-"], ["-", "-", "-", "-", "-"]]]
             }
         }
 
         LocalStorage.saveCreatorChallenge(challenge)
-        render(<SceneGrid />)
+        renderWithContext(<SceneGrid />)
 
         expect((await getGridSize()).rows).toBe(3)
         expect((await getGridSize()).columns).toBe(5)
@@ -39,16 +40,16 @@ describe('Scene grid', () => {
     })
 
     //Will change with refactor
-    test.skip('Should set grid size to default when there is no challenge saved', async () => {
+    test('Should set grid size to default when there is no challenge saved', async () => {
         localStorage.clear()
-        render(<SceneGrid />)
+        renderWithContext(<SceneGrid />)
 
         expect((await getGridSize()).rows).toBe(3)
         expect((await getGridSize()).columns).toBe(3)
 
     })
 
-    test.skip('Should have both object images in a cell when there is a & operator', async () =>{
+    test('Should have both object images in a cell when there is a & operator', async () => {
         const challenge: SerializedChallenge = {
             ...defaultChallenge("Duba"),
             scene: {
@@ -56,9 +57,9 @@ describe('Scene grid', () => {
                 maps: [[["A&P"]]]
             }
         }
-        
+
         LocalStorage.saveCreatorChallenge(challenge)
-        render(<SceneGrid />)
+        renderWithContext(<SceneGrid />)
         expect(await getAmountFromChallenge('cell-image')).toBe(2)
     })
 

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from "react";
 import { I18nextProvider } from "react-i18next";
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import i18n from "../i18n";
+import { CreatorContextProvider } from "../components/creator/Editor/CreatorContext";
 
 /**
  * Renders a component for testing purposes.
@@ -30,4 +31,12 @@ export const renderComponent = (
             } />
         </Routes>
     </MemoryRouter>)
+}
+
+export const renderWithContext = (component: ReactElement) => {
+  render(
+      <CreatorContextProvider>
+          {component}
+      </CreatorContextProvider>
+  )
 }


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1383
Resolves https://github.com/Program-AR/pilas-bloques/issues/1373

No logré sacar el currentMap para tenerlos por separado, asi que lo deje igual pero para que sea mas fácil usar el context agregué el index y map aparte. 

![Grabación de pantalla desde 20-07-23 14 39 45](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/7d23a7c7-5bc4-43fc-9e55-fc6bb2cde354)

Un detallito que me encontré es que hay que cambiar en exercises las escenas de los personajes para acomodarlos cuando tengan dos elementos en la celda, ahora se ve así:

![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/510e1dd4-b03a-4ba2-92c7-3451d9dab2a4)

