### PR TITLE
Visual style fixes

### DIFF
--- a/src/components/PBCard.tsx
+++ b/src/components/PBCard.tsx
@@ -10,6 +10,6 @@ export const PBCard = (props: PBCardProps & PaperProps) =>
     <Paper 
         {...props} 
         elevation={3} 
-        sx={{ ...props.sx, display: 'flex', alignItems: 'center', margin: theme.spacing(1)}}>
+        sx={{ ...props.sx, backgroundColor:'var(--theme-background-color)', display: 'flex', alignItems: 'center', margin: theme.spacing(1)}}>
             {props.children}
     </Paper>

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -15,14 +15,10 @@ import { DownloadButton } from "./ActionButtons/DownloadButton";
 export const CreatorEditor = () => {
   const {t} = useTranslation('creator')
 
-  // TODO BackGroundColor in Stack
-  // sx={{backgroundColor:'#311C3B'}} violet
-  // sx={{backgroundColor:'var(--theme-background-color)'}}> AppBar Color
-  // no bgcolor = body color
   return (
     <CreatorContextProvider>
       
-      <Stack alignItems="center" height="100%" sx={{backgroundColor:'var(--theme-background-color)'}}>
+      <Stack alignItems="center" sx={{backgroundColor: 'var(--theme-background-secondary-color)'}}>
         <Header CenterComponent={<HeaderText text={t("editor.editorHeader")}/>} SubHeader={<EditorSubHeader/>}/>
         <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 630}}>
           <SceneEdition />

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -15,9 +15,14 @@ import { DownloadButton } from "./ActionButtons/DownloadButton";
 export const CreatorEditor = () => {
   const {t} = useTranslation('creator')
 
+  // TODO BackGroundColor in Stack
+  // sx={{backgroundColor:'#311C3B'}} violet
+  // sx={{backgroundColor:'var(--theme-background-color)'}}> AppBar Color
+  // no bgcolor = body color
   return (
     <CreatorContextProvider>
-      <Stack alignItems="center" height="100%" sx={{backgroundColor:'#311C3B'}}>
+      
+      <Stack alignItems="center" height="100%" sx={{backgroundColor:'var(--theme-background-color)'}}>
         <Header CenterComponent={<HeaderText text={t("editor.editorHeader")}/>} SubHeader={<EditorSubHeader/>}/>
         <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 630}}>
           <SceneEdition />

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -17,7 +17,7 @@ export const CreatorEditor = () => {
 
   return (
     <CreatorContextProvider>
-      <Stack alignItems="center" height="100%" sx={{backgroundColor:'var(--theme-background-color)'}}>
+      <Stack alignItems="center" height="100%" sx={{backgroundColor:'#311C3B'}}>
         <Header CenterComponent={<HeaderText text={t("editor.editorHeader")}/>} SubHeader={<EditorSubHeader/>}/>
         <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 630}}>
           <SceneEdition />

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -17,7 +17,7 @@ export const CreatorEditor = () => {
 
   return (
     <CreatorContextProvider>
-      <Stack alignItems="center" height="100%">
+      <Stack alignItems="center" height="100%" sx={{backgroundColor:'var(--theme-background-color)'}}>
         <Header CenterComponent={<HeaderText text={t("editor.editorHeader")}/>} SubHeader={<EditorSubHeader/>}/>
         <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 630}}>
           <SceneEdition />

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
@@ -19,7 +19,7 @@ export const SceneGrid = (props: SceneGridProps) => {
 
     const sceneType: SceneType = challenge.scene.type
 
-    return <PBCard sx={{flexGrow: 1}}>
+    return <PBCard sx={{flexGrow: 1, justifyContent:"space-evenly"}}>
         <Stack className={styles.grid} style={props.styling}>
             {map.map((row, i) =>
                 <Stack key={i + row.join(',')} direction="row" data-testid="challenge-row">

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -48,7 +48,7 @@ const SizeEditor = (props: SizeProps) => {
     }
 
     const updateStyleGrid = useCallback(()=> {
-        const widthValue = ((columns/rows)*78).toFixed(0) + '%';
+        const widthValue = ((columns/rows)*75).toFixed(0) + '%';
         if ( width !== widthValue )
         {
             setWidth(widthValue)

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -48,7 +48,7 @@ const SizeEditor = (props: SizeProps) => {
     }
 
     const updateStyleGrid = useCallback(()=> {
-        const widthValue = ((columns/rows)*50).toFixed(0) + '%';
+        const widthValue = ((columns/rows)*78).toFixed(0) + '%';
         if ( width !== widthValue )
         {
             setWidth(widthValue)

--- a/src/components/creator/Editor/SceneEdition/SceneTools.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneTools.tsx
@@ -40,8 +40,10 @@ export const SceneTools = () => {
 
     const PutObstacleTool = () => 
         <>
-            <Tool id="O" image={`${imagePathScene}/O.png`} /> 
-            <Typography variant="caption">{t('tools.putObstacle')}</Typography>
+            <Stack alignItems="center">
+                <Tool id="O" image={`${imagePathScene}/O.png`} /> 
+                <Typography variant="caption">{t('tools.putObstacle')}</Typography>
+            </Stack>
         </>
 
     const PutObjectTool = () => 
@@ -55,14 +57,18 @@ export const SceneTools = () => {
 
     const PutActorTool = () => 
         <>
-            <Tool id="A" image={`${imagePathScene}/tool.png`}/>
-            <Typography variant="caption">{t('tools.putActor')}</Typography>
+            <Stack alignItems="center">
+                <Tool id="A" image={`${imagePathScene}/tool.png`}/>
+                <Typography variant="caption">{t('tools.putActor')}</Typography>
+            </Stack>
         </>
                         
     const DeleteTool = () => 
         <>
-            <Tool id="-" image={`${imagePath}/eraser.png`}/>
-            <Typography variant="caption">{t('tools.delete')}</Typography>
+            <Stack alignItems="center">
+                <Tool id="-" image={`${imagePath}/eraser.png`}/>
+                <Typography variant="caption">{t('tools.delete')}</Typography>
+            </Stack>
         </>     
 
 


### PR DESCRIPTION
Fixes https://github.com/Program-AR/pilas-bloques/issues/1387

Se resolvió el error de ubicacion del mapa y sus celdas
Se acercaron los textos a cada tool.
Se puso el mismo color de fondo del appbar al PBCard
Se probaron las alternativas del background total 
Que quede en blanco (o con el color del body)
![white](https://github.com/Program-AR/pilas-bloques-react/assets/91342656/c04ce5c0-e757-4fc3-9f02-9a583a2a31c5)

Que sea el background que quedó hoy del footer 
![theme-background-color](https://github.com/Program-AR/pilas-bloques-react/assets/91342656/1afd515f-1ede-407a-90d0-352321b35015)

Se probó con el violeta
![violeta](https://github.com/Program-AR/pilas-bloques-react/assets/91342656/92775967-9f42-4f8c-b5b9-21b961dd3086)

Este ultimo hace que se pierda el objetivo del Paper que es la sombra y lo tenue del borde.
