### PR TITLE
Problemillas de responsiveness

### DIFF
--- a/locales/en-us/creator.json
+++ b/locales/en-us/creator.json
@@ -19,9 +19,13 @@
 		"title": "Write your title",
 		"buttons": {
 			"discardChallenge": "Discard challenge",
+			"discardChallengeShort": "Discard",
 			"download": "Download",
 			"preview": "Challenge preview",
-			"keepEditing": "Keep editing"
+			"previewShort": "Preview",
+			"keepEditing": "Keep editing",
+			"keepEditingShort": "Edit"
+
 		},
 		"editorHeader": "Edit challenge",
 		"previewModeHeader": "Challenge preview"

--- a/locales/es-ar/creator.json
+++ b/locales/es-ar/creator.json
@@ -19,9 +19,13 @@
 		"title": "Escribir título",
 		"buttons": {
 			"discardChallenge": "Descartar desafio",
+			"discardChallengeShort": "Descartar",
 			"download": "Descargar",
 			"preview": "Ver desafio",
-			"keepEditing": "Seguir editando"
+			"previewShort": "Ver",
+			"keepEditing": "Seguir editando",
+			"keepEditingShort": "Editar"
+
 		},
 		"editorHeader": "Editar desafio",
 		"previewModeHeader": "Ver desafio"

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,8 @@
 :root {
     --header-height: 48px;
+    --creator-subheader-height: 60px;
+    --creator-max-width: 1024px;
+    --creator-max-height: 630px;
 }
   
 html, body, #root {

--- a/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
@@ -9,7 +9,7 @@ type CreatorActionButtonProps = {
 export const CreatorActionButton = ({ isshortversion = false, ...props} : CreatorActionButtonProps) => {
   const { t } = useTranslation('creator')
 
-  const isSmallScreen: boolean = useMediaQuery('(max-width:800px)');
+  const isSmallScreen: boolean = useMediaQuery('(max-width:814px)');
 
   return < Button {...props} variant="outlined" sx={{
     textTransform: "none",

--- a/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
@@ -2,11 +2,11 @@ import { Button, ButtonProps, useMediaQuery } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 type CreatorActionButtonProps = {
-  nameTag: string,
-  isShortVersion?: boolean
+  nametag: string,
+  isshortversion?: boolean
 } & ButtonProps
 
-export const CreatorActionButton = (props: CreatorActionButtonProps) => {
+export const CreatorActionButton = ({ isshortversion = false, ...props} : CreatorActionButtonProps) => {
   const { t } = useTranslation('creator')
 
   const isSmallScreen: boolean = useMediaQuery('(max-width:800px)');
@@ -14,6 +14,6 @@ export const CreatorActionButton = (props: CreatorActionButtonProps) => {
   return < Button {...props} variant="outlined" sx={{
     textTransform: "none",
     marginRight: '10px'}}>
-    {t(`editor.buttons.${props.nameTag}${!props.isShortVersion && isSmallScreen ? 'Short' : ''}`)}
+    {t(`editor.buttons.${props.nametag}${!isshortversion && isSmallScreen ? 'Short' : ''}`)}
   </Button >
 }

--- a/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
@@ -1,12 +1,19 @@
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, useMediaQuery } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 type CreatorActionButtonProps = {
-  backgroundcolor: string
+  nameTag: string,
+  isShortVersion?: boolean
 } & ButtonProps
 
-export const CreatorActionButton = (props: CreatorActionButtonProps) =>
-  <Button {...props} variant="outlined" sx={{
+export const CreatorActionButton = (props: CreatorActionButtonProps) => {
+  const { t } = useTranslation('creator')
+
+  const isSmallScreen: boolean = useMediaQuery('(max-width:800px)');
+
+  return < Button {...props} variant="outlined" sx={{
     textTransform: "none",
-    marginRight: '10px' }}>
-    {props.children}
-  </Button>
+    marginRight: '10px'}}>
+    {t(`editor.buttons.${props.nameTag}${!props.isShortVersion && isSmallScreen ? 'Short' : ''}`)}
+  </Button >
+}

--- a/src/components/creator/Editor/ActionButtons/DiscardChallengeButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/DiscardChallengeButton.tsx
@@ -5,7 +5,7 @@ import ClearIcon from '@mui/icons-material/Clear';
 export const DiscardChallengeButton = () => {
 
     return <Link to="/creador/seleccionar">
-            <CreatorActionButton startIcon={<ClearIcon/>} nameTag='discardChallenge'/>
+            <CreatorActionButton startIcon={<ClearIcon/>} nametag='discardChallenge'/>
         </Link>
 
 }

--- a/src/components/creator/Editor/ActionButtons/DiscardChallengeButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/DiscardChallengeButton.tsx
@@ -1,13 +1,11 @@
-import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { CreatorActionButton } from "./CreatorActionButton";
 import ClearIcon from '@mui/icons-material/Clear';
 
 export const DiscardChallengeButton = () => {
-    const {t} = useTranslation('creator')
 
     return <Link to="/creador/seleccionar">
-            <CreatorActionButton startIcon={<ClearIcon/>} backgroundcolor="#9d4444">{t("editor.buttons.discardChallenge")}</CreatorActionButton>
+            <CreatorActionButton startIcon={<ClearIcon/>} nameTag='discardChallenge'/>
         </Link>
 
 }

--- a/src/components/creator/Editor/ActionButtons/DownloadButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/DownloadButton.tsx
@@ -6,9 +6,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 
 export const DownloadButton = () => {
     
-    const { t } = useTranslation('creator');
-    
-    return <CreatorActionButton onClick={downloadChallenge} startIcon={<DownloadIcon/>} backgroundcolor="#65449d">{t("editor.buttons.download")}</CreatorActionButton>
+    return <CreatorActionButton onClick={downloadChallenge} startIcon={<DownloadIcon/>} nameTag='download' isShortVersion={true}/>
 
 }
 

--- a/src/components/creator/Editor/ActionButtons/DownloadButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/DownloadButton.tsx
@@ -6,7 +6,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 
 export const DownloadButton = () => {
     
-    return <CreatorActionButton onClick={downloadChallenge} startIcon={<DownloadIcon/>} nameTag='download' isShortVersion={true}/>
+    return <CreatorActionButton onClick={downloadChallenge} startIcon={<DownloadIcon/>} nametag='download' isshortversion={true}/>
 
 }
 

--- a/src/components/creator/Editor/ActionButtons/PreviewButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/PreviewButton.tsx
@@ -6,7 +6,7 @@ import { Visibility } from "@mui/icons-material";
 export const PreviewButton = () => {
 
     return <Link to="/creador/ver">
-            <CreatorActionButton startIcon={<Visibility/>} nameTag='preview'/>
+            <CreatorActionButton startIcon={<Visibility/>} nametag='preview'/>
         </Link>
 
 }

--- a/src/components/creator/Editor/ActionButtons/PreviewButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/PreviewButton.tsx
@@ -4,10 +4,9 @@ import { CreatorActionButton } from "./CreatorActionButton"
 import { Visibility } from "@mui/icons-material";
 
 export const PreviewButton = () => {
-    const {t} = useTranslation('creator')
 
     return <Link to="/creador/ver">
-            <CreatorActionButton startIcon={<Visibility/>} backgroundcolor="#449d99">{t("editor.buttons.preview")}</CreatorActionButton>
+            <CreatorActionButton startIcon={<Visibility/>} nameTag='preview'/>
         </Link>
 
 }

--- a/src/components/creator/Editor/ActionButtons/ReturnToEditButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/ReturnToEditButton.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 export const ReturnToEditionButtion = () => {
 
     return <Link to="/creador/editar">
-        <CreatorActionButton startIcon={<EditIcon />} nameTag='keepEditing' />
+        <CreatorActionButton startIcon={<EditIcon />} nametag='keepEditing' />
     </Link>
 
 }

--- a/src/components/creator/Editor/ActionButtons/ReturnToEditButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/ReturnToEditButton.tsx
@@ -3,13 +3,10 @@ import { CreatorActionButton } from "./CreatorActionButton";
 import EditIcon from '@mui/icons-material/Edit';
 import { useTranslation } from "react-i18next";
 
-export const ReturnToEditionButtion = () =>{
-    const {t} = useTranslation('creator')
+export const ReturnToEditionButtion = () => {
 
     return <Link to="/creador/editar">
-        <CreatorActionButton startIcon={<EditIcon/>} backgroundcolor="#449d99">
-            {t("editor.buttons.keepEditing")}
-        </CreatorActionButton>
+        <CreatorActionButton startIcon={<EditIcon />} nameTag='keepEditing' />
     </Link>
 
 }

--- a/src/components/creator/Editor/CreatorViewMode.tsx
+++ b/src/components/creator/Editor/CreatorViewMode.tsx
@@ -36,6 +36,6 @@ export const CreatorViewMode = () => {
     
     return <>
         <Header CenterComponent={<HeaderText text={t("editor.previewModeHeader")} />} SubHeader={<ViewModeSubHeader challenge={challengeBeingEdited}/>}/>
-        <EmberView path={EMBER_IMPORTED_CHALLENGE_PATH}/>
+        <EmberView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH}/>
     </>
 }

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -20,7 +20,7 @@ export const CreatorEditor = () => {
       
       <Stack alignItems="center" sx={{backgroundColor: 'var(--theme-background-secondary-color)'}}>
         <Header CenterComponent={<HeaderText text={t("editor.editorHeader")}/>} SubHeader={<EditorSubHeader/>}/>
-        <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 608}}>
+        <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)'}}>
           <SceneEdition />
         </Stack>
         <EditorFooter />

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -20,7 +20,7 @@ export const CreatorEditor = () => {
       
       <Stack alignItems="center" sx={{backgroundColor: 'var(--theme-background-secondary-color)'}}>
         <Header CenterComponent={<HeaderText text={t("editor.editorHeader")}/>} SubHeader={<EditorSubHeader/>}/>
-        <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 630}}>
+        <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 1024, maxHeight: 608}}>
           <SceneEdition />
         </Stack>
         <EditorFooter />

--- a/src/components/creator/Editor/EditorSubHeader/CreatorSubHeader.tsx
+++ b/src/components/creator/Editor/EditorSubHeader/CreatorSubHeader.tsx
@@ -2,7 +2,7 @@ import { Stack } from "@mui/material";
 
 export const CreatorSubHeader = ({ children }: { children: React.ReactNode }) => {
 
-    return <Stack direction='row' height='60px'  justifyContent='center' sx={{ backgroundColor: 'var(--theme-background-secondary-color)', zIndex:-1}}>
+    return <Stack direction='row' height='var(--creator-subheader-height)'  justifyContent='center' sx={{ backgroundColor: 'var(--theme-background-secondary-color)', zIndex:-1}}>
         <Stack direction='row' width='100%' alignItems='center' justifyContent='space-between' maxWidth='var(--creator-max-width)'>
             {children}
         </Stack>

--- a/src/components/creator/Editor/EditorSubHeader/CreatorSubHeader.tsx
+++ b/src/components/creator/Editor/EditorSubHeader/CreatorSubHeader.tsx
@@ -1,6 +1,10 @@
 import { Stack } from "@mui/material";
 
-export const CreatorSubHeader = ({children}: {children: React.ReactNode}) =>
-   <Stack height="60px" direction="row" justifyContent="center" alignItems="center" spacing={20} sx={{backgroundColor: 'var(--theme-background-secondary-color)'}}>
-        {children}
+export const CreatorSubHeader = ({ children }: { children: React.ReactNode }) => {
+
+    return <Stack direction='row' height='60px'  justifyContent='center' sx={{ backgroundColor: 'var(--theme-background-secondary-color)', zIndex:-1}}>
+        <Stack direction='row' width='100%' alignItems='center' justifyContent='space-between' maxWidth='var(--creator-max-width)'>
+            {children}
+        </Stack>
     </Stack>
+}

--- a/src/components/creator/Editor/EditorSubHeader/TitleEdition.tsx
+++ b/src/components/creator/Editor/EditorSubHeader/TitleEdition.tsx
@@ -18,7 +18,7 @@ export const TitleEdition = () => {
     }
 
     return <TextField
-        sx={{ width: "350px" }}
+        sx={{ width: "350px", margin: '0 10px' }}
         size="small"
         label={t('editor.title')}
         value={titleInProgress}

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
@@ -9,6 +9,7 @@ import { PBCard } from "../../../../PBCard"
 import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material"
 import { IconButtonTooltip } from "../IconButtonTooltip"
 import { useTranslation } from "react-i18next"
+import theme from "../../../../../theme"
 
 type SceneGridProps = {
     styling?: CSSProperties
@@ -39,8 +40,8 @@ export const SceneGrid = (props: SceneGridProps) => {
 
     return <PBCard sx={{ flexGrow: 1, justifyContent: "space-evenly" }}>
         <IconButtonTooltip disabled={atFirstMap} onClick={handleBack} icon={<KeyboardArrowLeft />} tooltip={t("mapNavigation.prev")} />
-        <Stack className={styles.grid} style={props.styling} data-testid="dummy-test-scene-grid">
-            <Typography variant="h6" sx={{padding: '20px', alignSelf: 'center'}}>{`${t("mapNavigation.multipleInitialScenarios")}: ${index + 1} / ${maps.length}`}</Typography>
+        <Stack justifyContent='flex-start' className={styles.grid} style={props.styling} data-testid="dummy-test-scene-grid">
+            <Typography variant="h6" sx={{marginBottom: theme.spacing(1), alignSelf: 'center'}}>{`${t("mapNavigation.multipleInitialScenarios")}: ${index + 1} / ${maps.length}`}</Typography>
 
             {currentMap.map((row, i) =>
                 <Stack key={i + row.join(',')} direction="row" data-testid="challenge-row">
@@ -54,7 +55,7 @@ export const SceneGrid = (props: SceneGridProps) => {
             <MobileStepper
                 variant="dots"
                 classes={{ dotActive: styles['active-dot'] }}
-                style={{ margin: '15px', backgroundColor: 'var(--theme-background-color)' }}
+                style={{ marginTop: theme.spacing(1), backgroundColor: 'var(--theme-background-color)' }}
                 position='static'
                 backButton={<span />}
                 nextButton={<span />}

--- a/src/components/creator/Editor/SceneEdition/GridOptions/IncDecButtons.tsx
+++ b/src/components/creator/Editor/SceneEdition/GridOptions/IncDecButtons.tsx
@@ -31,7 +31,7 @@ export const IncDecButtons = (props: IncDecButtonsProps) => {
                 <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", width: flexStyles.flexTextWidth }} >{props.value}</Box>
                 <Button style={{ fontSize: flexStyles.flexFontSize, minWidth: flexStyles.flexMinWidth, borderRight:"0px" }} onClick={()=>handleValue(true)} data-testid={`inc-btn-${props.testId}`}>+</Button>
             </ButtonGroup>
-            {props.label && <Typography sx={{marginTop: '5px'}} textAlign="center" variant="body1">{props.label}</Typography>}
+            {props.label && <Typography sx={{marginTop: '5px'}} textAlign="center" variant="subtitle2">{props.label}</Typography>}
         </Box>
     );
 }

--- a/src/components/creator/Editor/SceneEdition/GridOptions/SizeEditor.tsx
+++ b/src/components/creator/Editor/SceneEdition/GridOptions/SizeEditor.tsx
@@ -45,7 +45,7 @@ export const SizeEditor = (props: StyleGridProps) => {
     }
 
     const updateStyleGrid = useCallback(() => {
-        const widthValue = ((columns / rows) * 75).toFixed(0) + '%';
+        const widthValue = ((columns / rows) * 55).toFixed(0) + '%';
         if (width !== widthValue) {
             setWidth(widthValue)
             props.setStyleGrid({width: widthValue})

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -8,7 +8,7 @@ export const SceneEdition = () => {
     const [styleGrid, setStyleGrid] = useState<CSSProperties>({})
 
     return (
-        <Stack direction="row" alignItems="stretch" sx={{ height: "100%", padding: '30px' }}>
+        <Stack direction="row" alignItems="stretch" sx={{ height: "100%" }}>
             <GridOptions setStyleGrid={setStyleGrid} />
             <SceneGrid styling={styleGrid} />
             <SceneTools />

--- a/src/components/creator/Editor/SceneEdition/SceneTools.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneTools.tsx
@@ -38,53 +38,54 @@ export const SceneTools = () => {
                 backgroundPositionX: "center",
                 backgroundPositionY: "center",
                 boxShadow: `0 0px calc(10px * ${Number(props.id === selectedTool)})`,
-                width: "50px", height: "50px",                
-                marginTop: theme.spacing(1)
-            }} />
+                height:'40px',
+                marginTop: theme.spacing(0.8)
+    }
+} />
     }
 
-    type ToolGroupProps = {
-        children: React.ReactNode
-        type: string
-    }
+type ToolGroupProps = {
+    children: React.ReactNode
+    type: string
+}
 
-    const ToolGroup = (props: ToolGroupProps) =>
-        <Stack alignItems="center" sx={{ margin: '10px' }}>
-            {props.children}
-            <Typography sx={{ textAlign: 'center', marginTop: theme.spacing(0.5) }} variant="body1">{t(`tools.${props.type}`)}</Typography>
+const ToolGroup = (props: ToolGroupProps) =>
+    <Stack alignItems="center" sx={{ margin: theme.spacing(0.1) }}>
+        {props.children}
+        <Typography sx={{ textAlign: 'center', marginTop: theme.spacing(0.5) }} variant="subtitle2">{t(`tools.${props.type}`)}</Typography>
+    </Stack>
+
+const PutObstacleTool = () =>
+    <ToolGroup type='putObstacle'>
+        <Tool id="O" image={`${imagePathScene}/O.png`} />
+    </ToolGroup>
+
+const PutObjectTool = () =>
+    <ToolGroup type='putObject'>
+        {sceneObjectByType(challenge!.scene.type).validCells.map((object) =>
+            <Tool id={object} key={object} image={`${imagePathScene}/${object}.png`} />)}
+    </ToolGroup>
+
+const PutActorTool = () =>
+    <ToolGroup type='putActor'>
+        <Tool id="A" image={`${imagePathScene}/tool.png`} />
+    </ToolGroup>
+
+const DeleteTool = () =>
+    <ToolGroup type='delete'>
+        <Tool id="-" image={`${imagePath}/eraser.png`} />
+    </ToolGroup>
+
+return (
+    <PBCard>
+        <Stack alignItems="center" justifyContent="flex-start" style={{ padding: theme.spacing(1), height: "100%" }}>
+            <PutActorTool />
+            <PutObstacleTool />
+            <PutObjectTool />
+            <DeleteTool />
         </Stack>
-
-    const PutObstacleTool = () =>
-        <ToolGroup type='putObstacle'>
-            <Tool id="O" image={`${imagePathScene}/O.png`} />
-        </ToolGroup>
-
-    const PutObjectTool = () =>
-        <ToolGroup type='putObject'>
-            {sceneObjectByType(challenge!.scene.type).validCells.map((object) =>
-                <Tool id={object} key={object} image={`${imagePathScene}/${object}.png`} />)}
-        </ToolGroup>
-
-    const PutActorTool = () =>
-        <ToolGroup type='putActor'>
-            <Tool id="A" image={`${imagePathScene}/tool.png`} />
-        </ToolGroup>
-
-    const DeleteTool = () =>
-        <ToolGroup type='delete'>
-            <Tool id="-" image={`${imagePath}/eraser.png`} />
-        </ToolGroup>
-
-    return (
-        <PBCard>
-            <Stack alignItems="center" justifyContent="flex-start" style={{ padding: theme.spacing(1), height: "100%" }}>
-                <PutActorTool />
-                <PutObstacleTool />
-                <PutObjectTool />
-                <DeleteTool />
-            </Stack>
-        </PBCard>
-    )
+    </PBCard>
+)
 }
 
 

--- a/src/components/emberView/EmberView.tsx
+++ b/src/components/emberView/EmberView.tsx
@@ -2,12 +2,13 @@ import { Box } from "@mui/material"
 import styles from './ember-view.module.css';
 
 type EmberViewProps = {
-    path: string
+    path: string,
+    height?: string
 }
 
 export const EmberView = (props: EmberViewProps) => {
 
-    return <Box className={styles['ember-box']}>
+    return <Box height={props.height ? props.height : '100%'} className={styles['ember-box']}>
               <iframe className={styles['ember-iframe']} id="ember-iframe" title='ember-view' src={`emberPB/index.html#/${props.path}`}/>
             </Box> 
 }

--- a/src/components/emberView/ember-view.module.css
+++ b/src/components/emberView/ember-view.module.css
@@ -1,8 +1,8 @@
 .ember-box {
     margin-top: calc(var(--header-height)*(-1));
     display: flex;
-    height: 100%;
 }
+
 .ember-iframe {
     width: 100%;
     height: 100%;

--- a/src/theme-light.css
+++ b/src/theme-light.css
@@ -20,4 +20,6 @@
   --theme-failed-color: orangered;
   --theme-control-color: #1e21ff;
   --home-background: #311c3b;
+  --creator-max-width: 1024px;
+  --creator-max-height: 630px;
 }  

--- a/src/theme-light.css
+++ b/src/theme-light.css
@@ -20,6 +20,4 @@
   --theme-failed-color: orangered;
   --theme-control-color: #1e21ff;
   --home-background: #311c3b;
-  --creator-max-width: 1024px;
-  --creator-max-height: 630px;
 }  


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1395

Así quedó:
![Peek 2023-08-09 21-38](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/aa88164f-5cd0-4f7f-ba03-77da43a3b4a5)

Propuse sacar la palabra "desafío" cuando la pantalla es muy chica, porque si no queda medio feo:( 
![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/aaa3b380-cdda-4f6d-9e0a-b814a8557403)

Pero solo es en los casos de pantallas muy chicas asi que no se si realmente tiene sentido tenerlo así. Había pensado si no dejar solo los íconos pero no se entendía muy bien qué hacía cada uno (quizás en celus es confuso sin tooltip) como se entiende en los de los múltiples escenarios.

También achiqué la letra y saqué bastante del espacio que había entre los _grupos de tools_, pero me parece que se entiende que son cosas separadas, el espacio entre cada tool de por sí como que ayudo con eso, no se que les parece :eyes: 

Si me parece que queda muy chiquitito todo cuando tenes pantallas grandes, no se cómo se podría ver eso:( Siempre se puede hacer zoom igual.
