### PR TITLE
"Escenarios iniciales" centrado

### DIFF
--- a/src/components/creator/Editor/SceneEdition/Grid/Scenarios.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/Scenarios.tsx
@@ -1,0 +1,49 @@
+import { useContext } from "react";
+import { CreatorContext } from "../../CreatorContext";
+import { SceneGrid, SceneGridProps } from "./SceneGrid";
+import { useTranslation } from "react-i18next";
+import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
+import { Stack, Typography, MobileStepper, useMediaQuery } from "@mui/material";
+import theme from "../../../../../theme";
+import { PBCard } from "../../../../PBCard";
+import { IconButtonTooltip } from "../IconButtonTooltip";
+
+export const Scenarios = (props: SceneGridProps) => {
+    const { index, maps, setIndex } = useContext(CreatorContext)
+
+    const { t } = useTranslation('creator');
+
+    const isVerySmallScreen: boolean = useMediaQuery('(max-width:700px)');
+
+    const atFirstMap = index === 0
+    const atLastMap = index === maps.length - 1
+
+    const handleBack = () => {
+        if (atFirstMap) return
+        setIndex(index - 1)
+    }
+
+    const handleNext = () => {
+        if (atLastMap) return
+        setIndex(index + 1)
+    }
+
+    return <PBCard sx={{ flexGrow: 1 }}>
+        <Stack width='100%' justifyContent='space-between' alignItems='center'>
+            <Typography variant="h6" sx={{ marginTop: theme.spacing(2) }}>{`${isVerySmallScreen ? '' : t("mapNavigation.multipleInitialScenarios") + ':'} ${index + 1} / ${maps.length}`}</Typography>
+            <Stack width='100%' direction='row' justifyContent='space-between' alignItems='center'>
+                <IconButtonTooltip sx={{ marginLeft: theme.spacing(2) }} disabled={atFirstMap} onClick={handleBack} icon={<KeyboardArrowLeft />} tooltip={t("mapNavigation.prev")} />
+                <SceneGrid styling={props.styling} />
+                <IconButtonTooltip sx={{ marginRight: theme.spacing(2) }} disabled={atLastMap} onClick={handleNext} icon={<KeyboardArrowRight />} tooltip={t("mapNavigation.next")} />
+            </Stack>
+            <MobileStepper
+                variant="dots"
+                style={{ margin: theme.spacing(1), backgroundColor: 'var(--theme-background-color)' }}
+                position='static'
+                backButton={<span />}
+                nextButton={<span />}
+                activeStep={index}
+                steps={maps.length} />
+        </Stack>
+    </PBCard>
+}

--- a/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
+++ b/src/components/creator/Editor/SceneEdition/Grid/SceneGrid.tsx
@@ -1,67 +1,32 @@
-import { MobileStepper, Stack, Typography } from "@mui/material"
+import { Stack } from "@mui/material"
 import { SceneType, SerializedChallenge, defaultChallenge } from "../../../../serializedChallenge"
 import { LocalStorage } from "../../../../../localStorage"
 import styles from "./grid.module.css"
 import { SceneCell } from "./SceneCell"
 import { useContext, CSSProperties } from "react"
 import { CreatorContext } from "../../CreatorContext"
-import { PBCard } from "../../../../PBCard"
-import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material"
-import { IconButtonTooltip } from "../IconButtonTooltip"
-import { useTranslation } from "react-i18next"
-import theme from "../../../../../theme"
 
-type SceneGridProps = {
+export type SceneGridProps = {
     styling?: CSSProperties
 }
 
 export const SceneGrid = (props: SceneGridProps) => {
-    const { currentMap, index, maps, setIndex } = useContext(CreatorContext)
-
-    const { t } = useTranslation('creator');
+    const { currentMap } = useContext(CreatorContext)
 
     const storageChallenge = LocalStorage.getCreatorChallenge()
     const challenge: SerializedChallenge = storageChallenge ? storageChallenge : defaultChallenge('Duba')
 
     const sceneType: SceneType = challenge.scene.type
 
-    const atFirstMap = index === 0
-    const atLastMap = index === maps.length - 1
-
-    const handleBack = () => {
-        if (atFirstMap) return
-        setIndex(index - 1)
-    }
-
-    const handleNext = () => {
-        if (atLastMap) return
-        setIndex(index + 1)
-    }
-
-    return <PBCard sx={{ flexGrow: 1, justifyContent: "space-evenly" }}>
-        <IconButtonTooltip disabled={atFirstMap} onClick={handleBack} icon={<KeyboardArrowLeft />} tooltip={t("mapNavigation.prev")} />
-        <Stack justifyContent='flex-start' className={styles.grid} style={props.styling} data-testid="dummy-test-scene-grid">
-            <Typography variant="h6" sx={{marginBottom: theme.spacing(1), alignSelf: 'center'}}>{`${t("mapNavigation.multipleInitialScenarios")}: ${index + 1} / ${maps.length}`}</Typography>
-
-            {currentMap.map((row, i) =>
-                <Stack key={i + row.join(',')} direction="row" data-testid="challenge-row">
-                    {row.map((cellContent, j) =>
-                        <SceneCell
-                            position={{ row: i, column: j }}
-                            key={i * 100 + j + cellContent}
-                            content={cellContent}
-                            sceneType={sceneType} />)}
-                </Stack>)}
-            <MobileStepper
-                variant="dots"
-                classes={{ dotActive: styles['active-dot'] }}
-                style={{ marginTop: theme.spacing(1), backgroundColor: 'var(--theme-background-color)' }}
-                position='static'
-                backButton={<span />}
-                nextButton={<span />}
-                activeStep={index}
-                steps={maps.length} />
-        </Stack>
-        <IconButtonTooltip disabled={atLastMap} onClick={handleNext} icon={<KeyboardArrowRight />} tooltip={t("mapNavigation.next")} />
-    </PBCard>
+    return <Stack justifyContent='flex-start' className={styles.grid} style={props.styling} data-testid="dummy-test-scene-grid">
+        {currentMap.map((row, i) =>
+            <Stack key={i + row.join(',')} direction="row" data-testid="challenge-row">
+                {row.map((cellContent, j) =>
+                    <SceneCell
+                        position={{ row: i, column: j }}
+                        key={i * 100 + j + cellContent}
+                        content={cellContent}
+                        sceneType={sceneType} />)}
+            </Stack>)}
+    </Stack>
 }

--- a/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
+++ b/src/components/creator/Editor/SceneEdition/SceneEdition.tsx
@@ -1,8 +1,8 @@
 import { Stack } from "@mui/material";
-import { SceneGrid } from "./Grid/SceneGrid";
 import { SceneTools } from "./SceneTools";
 import { useState, CSSProperties } from 'react';
 import { GridOptions } from "./GridOptions/GridOptions";
+import { Scenarios } from "./Grid/Scenarios";
 
 export const SceneEdition = () => {
     const [styleGrid, setStyleGrid] = useState<CSSProperties>({})
@@ -10,7 +10,7 @@ export const SceneEdition = () => {
     return (
         <Stack direction="row" alignItems="stretch" sx={{ height: "100%" }}>
             <GridOptions setStyleGrid={setStyleGrid} />
-            <SceneGrid styling={styleGrid} />
+            <Scenarios styling={styleGrid} />
             <SceneTools />
         </Stack>
     )


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1402

Al componente del medio le puse de nombre "Scenarios", no se me ocurrió uno mejor, se aceptan propuestas :eyes:. Me pareció que la Grid debería ser justamente la grilla sola, no todo lo del medio.

![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/1576bd67-efaa-492f-ad26-da6ed95735bf)

Le saqué el texto cuando la pantalla es chica:
![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/68792d27-e134-465f-80f8-79e5a112f218)
