### PR TITLE
Fondo no blanco :DDDD

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,7 +6,6 @@
 }
 
 html, body, #root {
-    background-color: var(--theme-background-secondary-color);
     height: 100%;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -4,8 +4,9 @@
     --creator-max-width: 1024px;
     --creator-max-height: 660px;
 }
-  
+
 html, body, #root {
+    background-color: var(--theme-background-secondary-color);
     height: 100%;
 }
 

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -16,7 +16,7 @@ export const CreatorEditor = () => {
   return (
     <CreatorContextProvider>
       
-      <Stack alignItems="center" sx={{backgroundColor: 'var(--theme-background-secondary-color)'}}>
+      <Stack alignItems="center" >
         <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.editorHeader")}/></BetaBadge>} SubHeader={<EditorSubHeader/>}/>
         <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)'}}>
           <SceneEdition />

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -16,7 +16,7 @@ export const CreatorEditor = () => {
   return (
     <CreatorContextProvider>
       
-      <Stack alignItems="center" >
+      <Stack alignItems="center" height="inherit" sx={{backgroundColor: 'var(--theme-background-secondary-color)'}}>
         <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.editorHeader")}/></BetaBadge>} SubHeader={<EditorSubHeader/>}/>
         <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)'}}>
           <SceneEdition />


### PR DESCRIPTION
El sub header lo mantuve con la variable para que se mantenga en el preview del ejercicio

![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/4d9027b3-8794-4bd2-9e7f-b837fbc82c61)
