### PR TITLE
Header de desafío importado + minor visual fixes

### DIFF
--- a/locales/en-us/creator.json
+++ b/locales/en-us/creator.json
@@ -77,5 +77,6 @@
 		"next": "Next",
 		"prev": "Previous",
 		"multipleInitialScenarios": "Initial scenarios"
-	}
+	},
+	"importedChallengedHeader": "Challenge created by the community"
 }

--- a/locales/es-ar/creator.json
+++ b/locales/es-ar/creator.json
@@ -150,5 +150,6 @@
 		"next": "Siguiente",
 		"prev": "Anterior",
 		"multipleInitialScenarios": "Escenarios iniciales"
-	}
+	},
+	"importedChallengedHeader": "Desafío creado por la comunidad"
 }

--- a/src/components/ChallengeView.tsx
+++ b/src/components/ChallengeView.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, Typography, useMediaQuery } from "@mui/material";
+import { Typography, useMediaQuery } from "@mui/material";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { Challenge, getChallengeWithName, getPathToChallenge, PathToChallenge } from "../staticData/challenges";
 import { EmberView } from "./emberView/EmberView";
@@ -6,6 +6,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import { Header } from "./header/Header";
 import { useTranslation } from "react-i18next";
 import { useThemeContext } from "../theme/ThemeContext";
+import { PBreadcrumbs } from "./PBreadcrumbs";
 
 const ChallengeBreadcrumb = (path: PathToChallenge) => {
     const { theme } = useThemeContext()
@@ -18,7 +19,7 @@ const ChallengeBreadcrumb = (path: PathToChallenge) => {
     const shouldShowChapter = !isSmallScreen
 
     return <>
-        <Breadcrumbs separator=">" >
+        <PBreadcrumbs>
 
             <Link to="/">
                 <HomeIcon style={{ display: 'flex', color: '#787878' }} />
@@ -39,7 +40,7 @@ const ChallengeBreadcrumb = (path: PathToChallenge) => {
 
             <Typography>{t(`${path.challenge.id}.title`, { ns: "challenges" })}</Typography>
 
-        </Breadcrumbs>
+        </PBreadcrumbs>
     </>
 }
 

--- a/src/components/ChallengeView.tsx
+++ b/src/components/ChallengeView.tsx
@@ -5,11 +5,9 @@ import { EmberView } from "./emberView/EmberView";
 import HomeIcon from '@mui/icons-material/Home';
 import { Header } from "./header/Header";
 import { useTranslation } from "react-i18next";
-import { useThemeContext } from "../theme/ThemeContext";
 import { PBreadcrumbs } from "./PBreadcrumbs";
 
 const ChallengeBreadcrumb = (path: PathToChallenge) => {
-    const { theme } = useThemeContext()
 
     const { t } = useTranslation(["books", "challenges", "chapters", "groups"])
     const isSmallScreen: boolean = useMediaQuery('(max-width:1100px)');
@@ -27,15 +25,15 @@ const ChallengeBreadcrumb = (path: PathToChallenge) => {
             </Link>
 
             <Link to={`/libros/${path.book.id}`}>
-                <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t(`${path.book.id}.title`, { ns: "books" })}</Typography>
+                <Typography>{t(`${path.book.id}.title`, { ns: "books" })}</Typography>
             </Link>
 
             {shouldShowChapter &&
-                <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t(`${path.chapter.id}.title`, { ns: "chapters" })}</Typography>
+                <Typography>{t(`${path.chapter.id}.title`, { ns: "chapters" })}</Typography>
             }
 
             {shouldShowGroup &&
-                <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t(`${path.group.id}.title`, { ns: "groups" })}</Typography>
+                <Typography>{t(`${path.group.id}.title`, { ns: "groups" })}</Typography>
             }
 
             <Typography>{t(`${path.challenge.id}.title`, { ns: "challenges" })}</Typography>

--- a/src/components/ImportedChallengeView.tsx
+++ b/src/components/ImportedChallengeView.tsx
@@ -5,6 +5,7 @@ import { SerializedChallenge } from "./serializedChallenge";
 import { Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { PBreadcrumbs } from "./PBreadcrumbs";
+import { useThemeContext } from "../theme/ThemeContext";
 
 export const EMBER_IMPORTED_CHALLENGE_PATH = "desafio/react-imported-challenge"
 
@@ -20,19 +21,19 @@ export const ImportedChallengeView = () => {
 const ImportedChallengeViewBreadcrumb = () => {
 
     const { t } = useTranslation("creator")
+    const { theme } = useThemeContext()
 
     const location = useLocation();
     const importedChallenge: SerializedChallenge | undefined = location.state;
 
     if (!importedChallenge) throw new Error("No hay desafio importado :(")
 
-
     return <PBreadcrumbs>
         <Link to="/" style={{ textDecoration: 'none' }}>
-            <Typography>{t("importedChallengedHeader")}</Typography>
+            <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t("importedChallengedHeader")}</Typography>
         </Link>
 
-        <Typography>{importedChallenge.title}</Typography>
+        <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" }}}>{importedChallenge.title}</Typography>
 
     </PBreadcrumbs>
 }

--- a/src/components/ImportedChallengeView.tsx
+++ b/src/components/ImportedChallengeView.tsx
@@ -5,7 +5,6 @@ import { SerializedChallenge } from "./serializedChallenge";
 import { Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { PBreadcrumbs } from "./PBreadcrumbs";
-import { useThemeContext } from "../theme/ThemeContext";
 
 export const EMBER_IMPORTED_CHALLENGE_PATH = "desafio/react-imported-challenge"
 
@@ -21,7 +20,6 @@ export const ImportedChallengeView = () => {
 const ImportedChallengeViewBreadcrumb = () => {
 
     const { t } = useTranslation("creator")
-    const { theme } = useThemeContext()
 
     const location = useLocation();
     const importedChallenge: SerializedChallenge | undefined = location.state;
@@ -30,10 +28,10 @@ const ImportedChallengeViewBreadcrumb = () => {
 
     return <PBreadcrumbs>
         <Link to="/" style={{ textDecoration: 'none' }}>
-            <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t("importedChallengedHeader")}</Typography>
+            <Typography>{t("importedChallengedHeader")}</Typography>
         </Link>
 
-        <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" }}}>{importedChallenge.title}</Typography>
+        <Typography>{importedChallenge.title}</Typography>
 
     </PBreadcrumbs>
 }

--- a/src/components/ImportedChallengeView.tsx
+++ b/src/components/ImportedChallengeView.tsx
@@ -1,19 +1,40 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { EmberView } from "./emberView/EmberView";
-import { Header, HeaderText } from "./header/Header";
+import { Header } from "./header/Header";
 import { SerializedChallenge } from "./serializedChallenge";
+import { Typography } from "@mui/material";
+import { useThemeContext } from "../theme/ThemeContext";
+import { useTranslation } from "react-i18next";
+import { PBreadcrumbs } from "./PBreadcrumbs";
 
 export const EMBER_IMPORTED_CHALLENGE_PATH = "desafio/react-imported-challenge"
 
 
-export const ImportedChallengeView = () =>{
+export const ImportedChallengeView = () => {
+
+    return <>
+        <Header CenterComponent={<ImportedChallengeViewBreadcrumb />} />
+        <EmberView path={EMBER_IMPORTED_CHALLENGE_PATH} />
+    </>
+}
+
+const ImportedChallengeViewBreadcrumb = () => {
+
+    const { theme } = useThemeContext()
+    const { t } = useTranslation(["books", "challenges", "chapters", "groups"])
+
     const location = useLocation();
     const importedChallenge: SerializedChallenge | undefined = location.state;
 
     if (!importedChallenge) throw new Error("No hay desafio importado :(")
 
-    return <>
-        <Header CenterComponent={<HeaderText text={importedChallenge.title}/>}/>
-        <EmberView path={EMBER_IMPORTED_CHALLENGE_PATH}/>
-    </>
+
+    return <PBreadcrumbs>
+        <Link to="/" style={{ textDecoration: 'none' }}>
+            <Typography>Desafío creado por la comuinidad</Typography>
+        </Link>
+
+        <Typography>{importedChallenge.title}</Typography>
+
+    </PBreadcrumbs>
 }

--- a/src/components/ImportedChallengeView.tsx
+++ b/src/components/ImportedChallengeView.tsx
@@ -3,7 +3,6 @@ import { EmberView } from "./emberView/EmberView";
 import { Header } from "./header/Header";
 import { SerializedChallenge } from "./serializedChallenge";
 import { Typography } from "@mui/material";
-import { useThemeContext } from "../theme/ThemeContext";
 import { useTranslation } from "react-i18next";
 import { PBreadcrumbs } from "./PBreadcrumbs";
 
@@ -20,8 +19,7 @@ export const ImportedChallengeView = () => {
 
 const ImportedChallengeViewBreadcrumb = () => {
 
-    const { theme } = useThemeContext()
-    const { t } = useTranslation(["books", "challenges", "chapters", "groups"])
+    const { t } = useTranslation("creator")
 
     const location = useLocation();
     const importedChallenge: SerializedChallenge | undefined = location.state;
@@ -31,7 +29,7 @@ const ImportedChallengeViewBreadcrumb = () => {
 
     return <PBreadcrumbs>
         <Link to="/" style={{ textDecoration: 'none' }}>
-            <Typography>Desafío creado por la comuinidad</Typography>
+            <Typography>{t("importedChallengedHeader")}</Typography>
         </Link>
 
         <Typography>{importedChallenge.title}</Typography>

--- a/src/components/PBreadcrumbs.tsx
+++ b/src/components/PBreadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, BreadcrumbsProps, styled, useMediaQuery } from "@mui/material";
+import { Breadcrumbs, BreadcrumbsProps } from "@mui/material";
 import { useThemeContext } from "../theme/ThemeContext";
 
 type PBreadcrumbsProps = {
@@ -8,7 +8,8 @@ type PBreadcrumbsProps = {
 export const PBreadcrumbs = (props: PBreadcrumbsProps & BreadcrumbsProps) => {
     const { theme } = useThemeContext()
 
-    return <Breadcrumbs separator=">" sx={{'& .MuiBreadcrumbs-separator': {color: theme.palette.text.primary}, ...props.sx}} >
+    return <Breadcrumbs separator=">" sx={{[theme.breakpoints.down("sm")]: { display: "none" } , '& .MuiBreadcrumbs-separator': {color: theme.palette.text.primary}, ...props.sx}} >
         {props.children}
     </Breadcrumbs>
 }
+

--- a/src/components/PBreadcrumbs.tsx
+++ b/src/components/PBreadcrumbs.tsx
@@ -1,0 +1,14 @@
+import { Breadcrumbs, BreadcrumbsProps, styled, useMediaQuery } from "@mui/material";
+import { useThemeContext } from "../theme/ThemeContext";
+
+type PBreadcrumbsProps = {
+    children: React.ReactNode
+}
+
+export const PBreadcrumbs = (props: PBreadcrumbsProps & BreadcrumbsProps) => {
+    const { theme } = useThemeContext()
+
+    return <Breadcrumbs separator=">" sx={{'& .MuiBreadcrumbs-separator': {color: theme.palette.text.primary}, ...props.sx}} >
+        {props.children}
+    </Breadcrumbs>
+}

--- a/src/components/book/BookView.tsx
+++ b/src/components/book/BookView.tsx
@@ -6,12 +6,9 @@ import { Header } from "../header/Header";
 import HomeIcon from '@mui/icons-material/Home';
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useThemeContext } from "../../theme/ThemeContext";
 import { PBreadcrumbs } from "../PBreadcrumbs";
 
-const Breadcrumb = (book: Book) => {
-    const { theme } = useThemeContext()
-    
+const Breadcrumb = (book: Book) => {    
     const {t} = useTranslation("books")
 
 
@@ -21,7 +18,7 @@ const Breadcrumb = (book: Book) => {
             <HomeIcon style={{ display:'flex', color: '#787878'}}/> 
         </Link>
         
-        <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t(`${book.id}.title`)}</Typography>
+        <Typography>{t(`${book.id}.title`)}</Typography>
 
     </PBreadcrumbs>
 }

--- a/src/components/book/BookView.tsx
+++ b/src/components/book/BookView.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { useParams } from "react-router-dom";
 import { Book, getBook } from "../../staticData/books";
 import { EmberView } from "../emberView/EmberView";
@@ -7,6 +7,7 @@ import HomeIcon from '@mui/icons-material/Home';
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useThemeContext } from "../../theme/ThemeContext";
+import { PBreadcrumbs } from "../PBreadcrumbs";
 
 const Breadcrumb = (book: Book) => {
     const { theme } = useThemeContext()
@@ -14,7 +15,7 @@ const Breadcrumb = (book: Book) => {
     const {t} = useTranslation("books")
 
 
-    return <Breadcrumbs separator=">">
+    return <PBreadcrumbs>
 
         <Link to="/">
             <HomeIcon style={{ display:'flex', color: '#787878'}}/> 
@@ -22,7 +23,7 @@ const Breadcrumb = (book: Book) => {
         
         <Typography sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>{t(`${book.id}.title`)}</Typography>
 
-    </Breadcrumbs>
+    </PBreadcrumbs>
 }
 
 export const BookView = () => {

--- a/src/components/creator/ActorSelection/Actors.tsx
+++ b/src/components/creator/ActorSelection/Actors.tsx
@@ -219,7 +219,7 @@ export const Actors = () => {
     const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
 
     const goToCreator = () => {
-        LocalStorage.saveCreatorChallenge(defaultChallenge(actorSelected.actor.id, t("statement.defaultDescription")!))
+        LocalStorage.saveCreatorChallenge(defaultChallenge(actorSelected.actor.id, t("statement.defaultDescription")!, t("statement.defaultTitle")!))
         navigate("/creador/editar")
     }
   

--- a/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/CreatorActionButton.tsx
@@ -18,7 +18,7 @@ export const CreatorActionButton = ({ isshortversion = false, ...props }: Creato
     <Tooltip title={isSmallScreen ? t(`editor.buttons.${props.nametag}`) : ''}>
       <Button {...props} variant="outlined" 
         sx={{ textTransform: "none",
-              marginRight: '10px',
+              margin: '0 10px',
               whiteSpace: 'nowrap',
               ...props.sx
             }}>

--- a/src/components/creator/Editor/CreatorViewMode.tsx
+++ b/src/components/creator/Editor/CreatorViewMode.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from "@mui/material"
+import { Typography } from "@mui/material"
 import { Ember } from "../../../emberCommunication"
 import { LocalStorage } from "../../../localStorage"
 import { EMBER_IMPORTED_CHALLENGE_PATH } from "../../ImportedChallengeView"
@@ -6,37 +6,31 @@ import { EmberView } from "../../emberView/EmberView"
 import { Header, HeaderText } from "../../header/Header"
 import { SerializedChallenge } from "../../serializedChallenge"
 import { useTranslation } from "react-i18next"
-import { CreatorSubHeader } from "./EditorSubHeader/CreatorSubHeader"
-import { DownloadButton } from "./ActionButtons/DownloadButton"
 import { ReturnToEditionButton } from "./ActionButtons/ReturnToEditButton"
-import { DiscardChallengeButton } from "./ActionButtons/DiscardChallengeButton"
 import { BetaBadge } from "../BetaBadge"
-
-const ViewModeSubHeader = ({challenge}: {challenge: SerializedChallenge}) =>
-    <CreatorSubHeader>
-        <Box sx={{ width: "293px" }}>
-            <HeaderText text={challenge.title}/>
-        </Box>
-        <Actions />
-    </CreatorSubHeader>
-
-const Actions = () => <>
-    <ReturnToEditionButton/>
-    <Stack direction="row" alignItems={"center"}>
-        <DiscardChallengeButton/>
-        <DownloadButton/>
-    </Stack>
-    </>
+import { PBreadcrumbs } from "../../PBreadcrumbs"
+import { EditorSubHeader } from "./Editor"
 
 export const CreatorViewMode = () => {
-    const {t} = useTranslation('creator')
 
     const challengeBeingEdited: SerializedChallenge = LocalStorage.getCreatorChallenge()!
 
     Ember.importChallenge(challengeBeingEdited)
-    
+
     return <>
-        <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.previewModeHeader")} /></BetaBadge>} SubHeader={<ViewModeSubHeader challenge={challengeBeingEdited}/>}/>
-        <EmberView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH}/>
+        <Header CenterComponent={<CreatorViewHeader challenge={challengeBeingEdited}/>} SubHeader={<EditorSubHeader viewButton={<ReturnToEditionButton/>}/>} />
+        <EmberView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH} />
     </>
+}
+
+const CreatorViewHeader = ({ challenge }: { challenge: SerializedChallenge }) => {
+    const { t } = useTranslation('creator')
+    
+    return <BetaBadge smaller={true}>
+        <PBreadcrumbs>
+            <HeaderText text={t("editor.previewModeHeader")} />
+            <Typography>{challenge.title}</Typography>
+        </PBreadcrumbs>
+    </BetaBadge>
+
 }

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -13,14 +13,13 @@ import { useThemeContext } from "../../../theme/ThemeContext";
 export const CreatorEditor = () => {
   const { theme } = useThemeContext()
 
-  const {t} = useTranslation('creator')
+  const { t } = useTranslation('creator')
 
   return (
     <CreatorContextProvider>
-      
-      <Stack alignItems="center" height="inherit" sx={{backgroundColor: theme.palette.background.paper}}>
-        <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.editorHeader")}/></BetaBadge>} SubHeader={<EditorSubHeader/>}/>
-        <Stack justifyContent= "center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)'}}>
+      <Stack alignItems="center" height="inherit" sx={{ backgroundColor: theme.palette.background.paper }}>
+        <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.editorHeader")} /></BetaBadge>} SubHeader={<EditorSubHeader viewButton={<PreviewButton/>}/>} />
+        <Stack justifyContent="center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)' }}>
           <SceneEdition />
         </Stack>
       </Stack>
@@ -28,15 +27,13 @@ export const CreatorEditor = () => {
   )
 }
 
-const EditorSubHeader: React.FC = () => 
-  <CreatorSubHeader>
-    <DiscardChallengeButton/>
-    <Actions/>
-  </CreatorSubHeader>
+type EditorSubHeaderProps = {
+  viewButton: React.ReactNode
+}
 
-const Actions = () => <>
-  <PreviewButton/>
-  <Stack direction="row" alignItems={"center"}>
-    <DownloadButton/>
-  </Stack>
-</>
+export const EditorSubHeader = (props: EditorSubHeaderProps) =>
+  <CreatorSubHeader>
+    <DiscardChallengeButton />
+    {props.viewButton}
+    <DownloadButton />
+  </CreatorSubHeader>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -16,11 +16,9 @@ type HeaderTextProps = {
 }
 
 export const HeaderText = (props: HeaderTextProps) => {
-    const { theme } = useThemeContext()
 
 	return <Typography 
-		className={styles["header-text"]}
-		sx={{ [theme.breakpoints.down("sm")]: { display: "none" } }}>
+		className={styles["header-text"]}>
 		{props.text}
 	</Typography>
 }


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1423

![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/8b0ea8dc-46d5-4fe3-8062-f655f7016665)

Aproveché a alinear el botón de descartar que estaba un poco corrido antes:

![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/8b0ea8dc-46d5-4fe3-8062-f655f7016665)

También vi que no se estaba poniendo con el color correcto el separador de los breadcrumbs (no se veía).

![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/ff126d20-4f10-49c2-b31d-697ae70fcbe8)
