### PR TITLE
Sacando borde del iframe

### DIFF
--- a/src/components/emberView/ember-view.module.css
+++ b/src/components/emberView/ember-view.module.css
@@ -6,4 +6,5 @@
 .ember-iframe {
     width: 100%;
     height: 100%;
+    border: none;
 }


### PR DESCRIPTION
Quedaba medio raro:
![imagen](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/b2b17374-b5e1-41a5-8ba7-c00fa767da57)

Ahora:
![Captura desde 2023-09-19 12-32-06](https://github.com/Program-AR/pilas-bloques-react/assets/48812037/ba96c97f-31a5-43f7-84e4-52a920136501)
