### PR TITLE
Primero los inputs

### DIFF
--- a/locales/en-us/creator.json
+++ b/locales/en-us/creator.json
@@ -45,8 +45,6 @@
 		"button": "Write the statement",
 		"description": "Statement text",
 		"clue": "Clue",
-		"markdownTitle": "This is what your statement and clue will look like:",
-		"descriptionHint": "Write a sentence for the exercise. Make it concise and clearly express the goal. You can use **bold**, _italics_ and :wink: emojis with Markdown syntax.",
 		"includeClue": "Include a clue",
 		"defaultDescription": "Your **statement** will look like this...",
 		"defaultTitle": "Write your challenge's title..."

--- a/locales/en-us/creator.json
+++ b/locales/en-us/creator.json
@@ -43,7 +43,7 @@
 	"statement": {
 		"title": "Write the challenge's statement for ",
 		"button": "Write the statement",
-		"description": "Description",
+		"description": "Statement text",
 		"clue": "Clue",
 		"markdownTitle": "This is what your statement and clue will look like:",
 		"descriptionHint": "Write a sentence for the exercise. Make it concise and clearly express the goal. You can use **bold**, _italics_ and :wink: emojis with Markdown syntax.",

--- a/locales/es-ar/creator.json
+++ b/locales/es-ar/creator.json
@@ -116,7 +116,7 @@
 	"statement": {
 		"title": "Escribí el enunciado del desafío para ",
 		"button": "Escribir enunciado",
-		"description": "Descripción",
+		"description": "Texto del enunciado",
 		"markdownTitle": "Así se verán tu enunciado y pista:",
 		"descriptionHint": "Escribí un enunciado para el ejercicio. Que sea conciso y diga claramente el objetivo. Podés usar **negritas**, _cursivas_ y emojis :wink: con la sintaxis de Markdown.",
 		"clue": "Pista",

--- a/locales/es-ar/creator.json
+++ b/locales/es-ar/creator.json
@@ -117,8 +117,6 @@
 		"title": "Escribí el enunciado del desafío para ",
 		"button": "Escribir enunciado",
 		"description": "Texto del enunciado",
-		"markdownTitle": "Así se verán tu enunciado y pista:",
-		"descriptionHint": "Escribí un enunciado para el ejercicio. Que sea conciso y diga claramente el objetivo. Podés usar **negritas**, _cursivas_ y emojis :wink: con la sintaxis de Markdown.",
 		"clue": "Pista",
 		"includeClue": "Incluir una pista",
 		"defaultDescription": "Así se verá tu **enunciado**...",

--- a/src/components/creator/Editor/ChallengeDetailsEdition/StatementEdition.tsx
+++ b/src/components/creator/Editor/ChallengeDetailsEdition/StatementEdition.tsx
@@ -14,7 +14,7 @@ export const StatementEdition = (props: StatementEditionType) => {
 
     const { t } = useTranslation('creator');
 
-    const initialStatement = LocalStorage.getCreatorChallenge()!.statement.description
+    const initialStatement: string = LocalStorage.getCreatorChallenge()!.statement.description
     const initialClue = LocalStorage.getCreatorChallenge()!.statement.clue
     const actor = LocalStorage.getCreatorChallenge()!.scene.type
 

--- a/src/components/creator/Editor/ChallengeDetailsEdition/TitleEdition.tsx
+++ b/src/components/creator/Editor/ChallengeDetailsEdition/TitleEdition.tsx
@@ -12,7 +12,7 @@ export const TitleEdition = () => {
 
     const initialTitle = LocalStorage.getCreatorChallenge()!.title
     const actor = LocalStorage.getCreatorChallenge()!.scene.type
-    
+
     const [titleInProgress, setTitleInProgress] = useState<string>(initialTitle);
     
     const [dialogOpen, setDialogOpen] = useState<boolean>(false)
@@ -51,6 +51,7 @@ export const TitleEdition = () => {
                 variant="standard"
                 label={t('title.input')}
                 value={titleInProgress}
+                autoFocus
                 onChange={props => setTitleInProgress(props.target.value)}
                 inputProps={{maxLength: 38}}
             />            

--- a/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
@@ -25,7 +25,6 @@ export const MarkdownEditor = (props: MarkdownEditorProps) => {
     const textToShow: string = statementTextToShow === StatementTextToShow.STATEMENT ? props.statement : props.clue!
 
     return <>
-        <Typography variant="body1" marginY={theme.spacing(2)}>{t('statement.descriptionHint')}</Typography>
         <MarkdownInput setShowStatement={setShowStatement} statement={props.statement} clue={props.clue} setClue={props.setClue} setStatement={props.setStatement}/>
         <MarkdownResult text={textToShow} setShowStatement={setShowStatement} clueIsEnabled={!!props.clue}/>
     </>

--- a/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
@@ -25,8 +25,8 @@ export const MarkdownEditor = (props: MarkdownEditorProps) => {
     const textToShow: string = statementTextToShow === StatementTextToShow.STATEMENT ? props.statement : props.clue!
 
     return <>
-        <MarkdownResult text={textToShow} setShowStatement={setShowStatement} clueIsEnabled={!!props.clue}/>
         <Typography variant="body1" marginY={theme.spacing(2)}>{t('statement.descriptionHint')}</Typography>
         <MarkdownInput setShowStatement={setShowStatement} statement={props.statement} clue={props.clue} setClue={props.setClue} setStatement={props.setStatement}/>
+        <MarkdownResult text={textToShow} setShowStatement={setShowStatement} clueIsEnabled={!!props.clue}/>
     </>
 }

--- a/src/components/creator/Editor/MarkDownEdition/MarkdownInput.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownInput.tsx
@@ -41,6 +41,7 @@ export const MarkdownInput = (props: MarkdownInputProps) => {
     <>
     <TextField
         fullWidth
+        autoFocus
         size="small"
         multiline={true}
         inputProps={{ "data-testid": "statement-input" }}

--- a/src/components/creator/Editor/MarkDownEdition/MarkdownInput.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownInput.tsx
@@ -1,4 +1,4 @@
-import { Switch, FormControlLabel, TextField} from "@mui/material";
+import { Switch, FormControlLabel, TextField } from "@mui/material";
 import { StatementTextToShow } from "./MarkdownEditor";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
@@ -52,7 +52,6 @@ export const MarkdownInput = (props: MarkdownInputProps) => {
         sx={{marginTop: '10px'}}
         id="statement-input"
     />
-
     <FormControlLabel control={<Switch color="secondary" onChange={toggleClueEnabled} checked={clueIsEnabled}/>} label={t("statement.includeClue")}/>
 
     {clueIsEnabled ? 

--- a/src/components/creator/Editor/MarkDownEdition/MarkdownResult.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownResult.tsx
@@ -22,7 +22,6 @@ export const MarkdownResult = (props: MarkdownResultProps) => {
   const urlImage = `imagenes/sceneImages/${LocalStorage.getCreatorChallenge()!.scene.type}/tool.png` 
 
   return <>
-    <Typography>{t('statement.markdownTitle')}</Typography>
     <PBCard sx={{height:"80px"}}>
         <img height="100%" alt="actor" src={urlImage}/>
         <Stack width="50px" height="100%" alignItems="center" justifyContent="center" sx={{backgroundColor: darken(theme.palette.text.secondary, 0.13)}}>

--- a/src/components/modalDialog/GenericModalDialog.tsx
+++ b/src/components/modalDialog/GenericModalDialog.tsx
@@ -55,7 +55,7 @@ export const GenericModalDialog: FC<ModalDialogProps> = ({
           PaperComponent={isDraggable ? PaperComponent : undefined}
           aria-labelledby="draggable-dialog" 
         >          
-        <DialogTitle id="draggable-dialog" sx={{ cursor: `${isDraggable ? 'move':'auto'}`,  height: '45px', display: 'flex', alignItems: 'center'}}>{title}</DialogTitle>
+        <DialogTitle id="draggable-dialog" sx={{ cursor: `${isDraggable ? 'move':'auto'}`, fontWeight: 'bold', height: '50px', display: 'flex', alignItems: 'center'}}>{title}</DialogTitle>
         <DialogContent sx={{backgroundColor: theme.palette.background.default}}>
           {children}
         </DialogContent>

--- a/src/components/modalDialog/GenericModalDialog.tsx
+++ b/src/components/modalDialog/GenericModalDialog.tsx
@@ -50,6 +50,7 @@ export const GenericModalDialog: FC<ModalDialogProps> = ({
         <Dialog 
           open={isOpen} 
           {...dialogProps} 
+          disableRestoreFocus
           onClose={handleClose}
           PaperComponent={isDraggable ? PaperComponent : undefined}
           aria-labelledby="draggable-dialog" 


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1417

Lo tomé ya que con @rgonzalezt en el nacional vimos que lxs chicxs le daban click al sector donde está la muestra de como queda el enunciado y la pista, y no en el input.

Si los titulos aun no quedan lo suficientemente visibles como pide el issue, podemos agregar un `variant="h5"` en el  `<DialogTitle>` que seria el siguiente tamaño al actual

Ademas, agregué la funcionalidad del foco en el 1er input.

https://github.com/Program-AR/pilas-bloques-react/assets/91342656/bedc2064-0592-4169-ba5e-6239487ece9a





