### PR TITLE
No explotar si no hay desafio

### DIFF
--- a/src/components/creator/Editor/CreatorViewMode.tsx
+++ b/src/components/creator/Editor/CreatorViewMode.tsx
@@ -10,6 +10,8 @@ import { ReturnToEditionButton } from "./ActionButtons/ReturnToEditButton"
 import { BetaBadge } from "../BetaBadge"
 import { PBreadcrumbs } from "../../PBreadcrumbs"
 import { EditorSubHeader } from "./Editor"
+import { useEffect } from "react"
+import { useNavigate } from "react-router-dom"
 
 export const CreatorViewMode = () => {
 
@@ -17,15 +19,29 @@ export const CreatorViewMode = () => {
 
     Ember.importChallenge(challengeBeingEdited)
 
-    return <>
-        <Header CenterComponent={<CreatorViewHeader challenge={challengeBeingEdited}/>} SubHeader={<EditorSubHeader viewButton={<ReturnToEditionButton/>}/>} />
-        <EmberView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH} />
-    </>
+    const navigate = useNavigate()
+
+    const challengeExists = LocalStorage.getCreatorChallenge()
+
+    useEffect(() => {
+        if (!challengeExists) {
+            navigate('/creador/seleccionar')
+        }
+    }, [])
+
+    return (<>
+        {challengeExists ? (
+            <>
+                <Header CenterComponent={<CreatorViewHeader challenge={challengeBeingEdited} />} SubHeader={<EditorSubHeader viewButton={<ReturnToEditionButton />} />} />
+                <EmberView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH} />
+            </>
+        ) : <></>}
+    </>)
 }
 
 const CreatorViewHeader = ({ challenge }: { challenge: SerializedChallenge }) => {
     const { t } = useTranslation('creator')
-    
+
     return <BetaBadge smaller={true}>
         <PBreadcrumbs>
             <HeaderText text={t("editor.previewModeHeader")} />

--- a/src/components/creator/Editor/CreatorViewMode.tsx
+++ b/src/components/creator/Editor/CreatorViewMode.tsx
@@ -24,9 +24,7 @@ export const CreatorViewMode = () => {
     const challengeExists = LocalStorage.getCreatorChallenge()
 
     useEffect(() => {
-        if (!challengeExists) {
-            navigate('/creador/seleccionar')
-        }
+        if (!challengeExists) navigate('/creador/seleccionar')
     }, [])
 
     return (<>

--- a/src/components/creator/Editor/CreatorViewMode.tsx
+++ b/src/components/creator/Editor/CreatorViewMode.tsx
@@ -25,7 +25,7 @@ export const CreatorViewMode = () => {
 
     useEffect(() => {
         if (!challengeExists) navigate('/creador/seleccionar')
-    }, [])
+    }, [challengeExists, navigate])
 
     return (<>
         {challengeExists ? (

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -23,9 +23,7 @@ export const CreatorEditor = () => {
   const challengeExists = LocalStorage.getCreatorChallenge()
 
   useEffect(() => {
-    if (!challengeExists) {
-      navigate('/creador/seleccionar')
-    }
+    if (!challengeExists) navigate('/creador/seleccionar')
   }, [])
 
   return (

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -9,21 +9,39 @@ import { DiscardChallengeButton } from "./ActionButtons/DiscardChallengeButton";
 import { PreviewButton } from "./ActionButtons/PreviewButton";
 import { BetaBadge } from "../BetaBadge";
 import { useThemeContext } from "../../../theme/ThemeContext";
+import { useNavigate } from "react-router-dom";
+import { LocalStorage } from "../../../localStorage";
+import { useEffect } from "react";
 
 export const CreatorEditor = () => {
   const { theme } = useThemeContext()
 
   const { t } = useTranslation('creator')
 
+  const navigate = useNavigate()
+
+  const challengeExists = LocalStorage.getCreatorChallenge()
+
+  useEffect(() => {
+    if (!challengeExists) {
+      navigate('/creador/seleccionar')
+    }
+  }, [])
+
   return (
-    <CreatorContextProvider>
-      <Stack alignItems="center" height="inherit" sx={{ backgroundColor: theme.palette.background.paper }}>
-        <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.editorHeader")} /></BetaBadge>} SubHeader={<EditorSubHeader viewButton={<PreviewButton/>}/>} />
-        <Stack justifyContent="center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)' }}>
-          <SceneEdition />
+    <>   
+    { challengeExists ?
+      (<CreatorContextProvider>
+        <Stack alignItems="center" height="inherit" sx={{ backgroundColor: theme.palette.background.paper }}>
+          <Header CenterComponent={<BetaBadge smaller={true}><HeaderText text={t("editor.editorHeader")} /></BetaBadge>} SubHeader={<EditorSubHeader viewButton={<PreviewButton />} />} />
+          <Stack justifyContent="center" height="100%" width="100%" sx={{ maxWidth: 'var(--creator-max-width)', maxHeight: 'var(--creator-max-height)' }}>
+            <SceneEdition />
+          </Stack>
         </Stack>
-      </Stack>
-    </CreatorContextProvider>
+      </CreatorContextProvider>
+      ) : <></>}
+    </>
+
   )
 }
 

--- a/src/components/creator/Editor/Editor.tsx
+++ b/src/components/creator/Editor/Editor.tsx
@@ -24,7 +24,7 @@ export const CreatorEditor = () => {
 
   useEffect(() => {
     if (!challengeExists) navigate('/creador/seleccionar')
-  }, [])
+  }, [challengeExists, navigate])
 
   return (
     <>   


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1507

Pasaba lo mismo con la ruta de _ver desafío_ asi que está en ambos. 

Mi primera opción para resolver esto fue la siguiente: 

```typescript
  {
    path: "/creador/editar",
    element: <CreatorEditor/>,
    errorElement: <ActorSelection />
  },
  {
    path: "/creador/ver",
    element: <CreatorViewMode/>,
    errorElement: <ActorSelection />
  }
  ```
  
Hacer que si falla renderice el selector. Esto no me gustó por dos razones: perdemos control sobre manejo de errores porque cualquier otro tipo de error al renderizar el componente (que no sea null challenge) estaría renderizando el selector; por otro lado no cambia la url, queda en editar/ver.

Si bien la solución del PR repite código (:crying_cat_face:) de cierta forma, me parece mejor tener el control sobre este caso especifico de qué queremos que pase si no hay un challenge, y en el futuro si tenemos otros tipos de errores manejarlos como correspondan. 

Cualquier cosa, se puede poner la otra versión de solución :+1: 