### PR TITLE
Error al borrar el enunciado

### DIFF
--- a/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
@@ -18,6 +18,12 @@ export const MarkdownEditor = (props: MarkdownEditorProps) => {
     const [statementTextToShow, setShowStatement] = useState<StatementTextToShow>(StatementTextToShow.STATEMENT)
     const textToShow: string = statementTextToShow === StatementTextToShow.STATEMENT ? props.statement : props.clue!
 
+    // La sentencia translate="no" evita la traducción del contenido de la pagina cuando está activada en Chrome/Safari 
+    // con motivo del error que se producía: "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node"
+    // similar a lo descripto en la siguiente documentacion por ser un inconveniente entre React DOM vs Real DOM en la renderizacion 
+    // cuando Chrome o Safari modifican el html para producir la traduccion en linea, lo hace solo en uno de ellos provocando el error.
+    // https://github.com/facebook/react/issues/17256
+    // Se aplica esta solucion https://stackoverflow.com/questions/12238396/how-to-disable-google-translate-from-html-in-chrome/12238414#12238414
     return <span translate="no">
         <MarkdownInput setShowStatement={setShowStatement} statement={props.statement} clue={props.clue} setClue={props.setClue} setStatement={props.setStatement}/>
         <MarkdownResult text={textToShow} setShowStatement={setShowStatement} clueIsEnabled={!!props.clue}/>

--- a/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
+++ b/src/components/creator/Editor/MarkDownEdition/MarkdownEditor.tsx
@@ -18,8 +18,8 @@ export const MarkdownEditor = (props: MarkdownEditorProps) => {
     const [statementTextToShow, setShowStatement] = useState<StatementTextToShow>(StatementTextToShow.STATEMENT)
     const textToShow: string = statementTextToShow === StatementTextToShow.STATEMENT ? props.statement : props.clue!
 
-    return <>
+    return <span translate="no">
         <MarkdownInput setShowStatement={setShowStatement} statement={props.statement} clue={props.clue} setClue={props.setClue} setStatement={props.setStatement}/>
         <MarkdownResult text={textToShow} setShowStatement={setShowStatement} clueIsEnabled={!!props.clue}/>
-    </>
+    </span>
 }


### PR DESCRIPTION
Resolves https://github.com/Program-AR/pilas-bloques/issues/1518

El problema no solo ocurre en windows. Ocurre en todos los OS y en Chrome o Safari con la opcion de traducir activada. 
Es un problema con el DOM de React y el real DOM que, cuando se indica para traducir, agrega al html el tag `<html lang="es" class="translated-ltr">` y lo hace en uno de los DOM, por lo que provoca esta inconsistencia y el error en consecuencia segun pude ver en alguna pagina que explican el problema.
La documentacion en internet indica mas o menos esto en diferentes casos y hasta donde pude leer, no hay una solucion definitiva, pero si hay una manera de evitar que ocurra con una entrada que coloqué en el MarkdownEditor.tsx de este PR.
Lo probé en Windows y en Linux (chrome en ambos casos) y ya no falla. La razon por la que estalla en este input y no en otros, es que el markdown es un input "especial" que rerenderiza casi permanentemente con lo que uno va escribiendo, cosa que no ocurre con los otros imputs del creador. Ocurre lo mismo con el input de la pista... (tiene la misma logica). La falla siempre esta dandose en estos inputs asociados al markdown.
Como es algo que está rompiendo PB me pareció mejor resolverlo asi para poder publicar rapidamente y dejar el tema, en tal caso, para adelante pero sin fallas y no ponerme a analizar profundamente el tema de React DOM y el traductor de chrome o safari y quiza tener que meter mano en el propio React (cosa que tambien vi que algunos hicieron).

Probé de quitar los `<></>` o (`<React.Fragment>` que es lo mismo) y reemplazarlos por `<div></div>` como sugieren en algunos comentarios, pero no lo resuelve en nuestro caso.

Adjunto documentacion que encontré sobre el tema:

https://github.com/remix-run/remix/issues/2943
https://github.com/facebook/react/issues/17256
https://github.com/facebook/react/issues/11538#issuecomment-417504600

