### PR TITLE
New layout and names

### DIFF
--- a/locales/es-ar/challenges.json
+++ b/locales/es-ar/challenges.json
@@ -438,13 +438,13 @@
       "title": "Mañic en el cielo"
     },
     "1005": {
-      "title": "Yvoty despierta a las luciérnagas"
+      "title": "Yvoty y las luciérnagas"
     },
     "1006": {
-      "title": "Chuy, campeone desordenade"
+      "title": "Campeone desordenade"
     },
     "1007": {
-      "title": "La reparadora de telescopios"
+      "title": "Reparadora de telescopios"
     },
     "1008": {
       "title": "Mañic y los planetas"
@@ -456,40 +456,40 @@
       "title": "Instalando juegos"
     },
     "1011": {
-      "title": "El gran escape en yacaré"
+      "title": "El gran escape"
     },
     "1012": {
       "title": "Limpiando el humedal"
     },
     "1013": {
-      "title": "Chuy y la pelota indecisa"
+      "title": "La pelota indecisa"
     },
     "1014": {
       "title": "¿Pelota o paleta?"
     },
     "1015": {
-      "title": "Chuy, jugadore de toda la cancha"
+      "title": "Jugadore de toda la cancha"
     },
     "1016": {
       "title": "Alineando telescopios"
     },
     "1017": {
-      "title": "Yvoty saca buenas fotos"
+      "title": "Tomando buenas fotos"
     },
     "1018": {
       "title": "Barrilete cósmico"
     },
     "1019": {
-      "title": "Super Yvoty 1"
+      "title": "Largos cambiantes"
     },
     "1020": {
-      "title": "Super Yvoty 2"
+      "title": "Luces cambiantes"
     },
     "1021": {
       "title": "Laberinto con pelotas"
     },
     "1022": {
-      "title": "Capy busca a Guyrá"
+      "title": "Buscando a Guyrá"
     },
     "1023": {
       "title": "Fútbol al sur"
@@ -498,49 +498,49 @@
       "title": "Prendiendo las compus"
     },
     "1025": {
-      "title": "Contando planetas y estrellas"
+      "title": "Contando astros"
     },
     "1026": {
-      "title": "Chuy sale a correr"
+      "title": "¡A correr!"
     },
     "1027": {
       "title": "Mañic cuenta de nuevo"
     },
     "1028": {
-      "title": "El humedal de Capy y Guyrá"
+      "title": "Reciclando con parámetros"
     },
     "1029": {
-      "title": "Dibujando: Al cuadrado"
+      "title": "Al cuadrado"
     },
     "1030": {
-      "title": "Dibujando: Rayuela"
+      "title": "Rayuela"
     },
     "1031": {
-      "title": "Dibujando: Corto por la diagonal"
+      "title": "Corto por la diagonal"
     },
     "1032": {
-      "title": "Dibujando: Mamushka cuadrada"
+      "title": "Mamushka cuadrada"
     },
     "1033": {
-      "title": "Dibujando: Escalera cuadrada"
+      "title": "Escalera cuadrada"
     },
     "1034": {
-      "title": "Dibujando: Hexágono"
+      "title": "Hexágono"
     },
     "1035": {
-      "title": "Dibujando: Pirámide invertida"
+      "title": "Pirámide invertida"
     },
     "1036": {
-      "title": "Dibujando: Figuras dentro de figuras"
+      "title": "Figuras en figuras"
     },
     "1037": {
-      "title": "Dibujando: La cueva de estalactitas"
+      "title": "La cueva de estalactitas"
     },
     "1038": {
       "title": "Las estrellas de Mañic"
     },
     "1039": {
-      "title": "La estrella interesante"
+      "title": "La estrella especial"
     },
     "1040": {
       "title": "Hilera de latas"
@@ -549,28 +549,28 @@
       "title": "Turistas latosos"
     },
     "1042": {
-      "title": "A veces latas, a veces papeles"
+      "title": "¿Latas o papeles?"
     },
     "1043": {
-      "title": "El pasillo curvo de celus"
+      "title": "Curvas de celus"
     },
     "1044": {
-      "title": "El festín astronómico"
+      "title": "Festín astronómico"
     },
     "1045": {
-      "title": "Fotografiando mariposas"
+      "title": "Mariposas"
     },
     "1046": {
       "title": "Nuevos Comandos"
     },
     "1130": {
-      "title": "Buscando las estrellas"
+      "title": "Buscando estrellas"
     },
     "1131": {
       "title": "Reciclando papeles"
     },
     "1132": {
-      "title": "Prendiendo las compus parametrizado"
+      "title": "Prendiendo las compus: parámetros"
     },
     "1133": {
       "title": "Mariposas encuadradas"

--- a/locales/es-ar/groups.json
+++ b/locales/es-ar/groups.json
@@ -195,6 +195,6 @@
       "title": "Con Toto"
     },
     "dibujando": {
-      "title": ""
+      "title": "Dibujando constelaciones"
     }
   }

--- a/src/components/book/BookView.tsx
+++ b/src/components/book/BookView.tsx
@@ -1,4 +1,4 @@
-import { Divider, Stack, Typography } from "@mui/material";
+import { Divider, Stack, Typography, useMediaQuery } from "@mui/material";
 import { useParams } from "react-router-dom";
 import { Book, getBook } from "../../staticData/books";
 import { Header } from "../header/Header";
@@ -62,7 +62,7 @@ const ChapterView = ({chapter}: {chapter: Chapter}) => {
         <Typography variant="h5" sx={{ fontWeight: 'bold' }}>{t(`${chapter.id}.title`)}</Typography>
         {   // We stack in a row unitary groups (for intermediate and advanced books)
             chapter.groups[0].hasOnlyOneChallenge() ? 
-                <Stack direction="row" flexWrap="wrap"><Groups/></Stack> : 
+                <ChallengeRow><Groups/></ChallengeRow> : 
                 <Groups/>
         }
     </> 
@@ -70,25 +70,33 @@ const ChapterView = ({chapter}: {chapter: Chapter}) => {
 
 const GroupView = ({group}: {group: Group}) => {
     const {t} = useTranslation("groups")
-    return <>
+    return <Stack>
         {   // We don't show the title for unitary groups (for intermediate and advanced books)
             !group.hasOnlyOneChallenge() && <Typography variant="h6">{t(`${group.id}.title`)}</Typography>
         }
-        <Stack direction="row" flexWrap="wrap">
+        <ChallengeRow>
             {group.challenges.map( challenge => <ChallengeCard key={challenge.id} challenge={challenge} /> ) }
-        </Stack>
-    </>
+        </ChallengeRow>
+    </Stack>
+}
+
+const ChallengeRow: React.FC <{children: React.ReactNode}> = ({children}) => {
+    const { theme } = useThemeContext()
+    const isVerySmallScreen: boolean = useMediaQuery(theme.breakpoints.down("sm"));
+    return <Stack direction="row" flexWrap="wrap"  justifyContent={isVerySmallScreen ? "space-evenly" : "flex-start"}>
+        {children}
+    </Stack>
 }
                             
 const ChallengeCard = ({challenge}:{challenge: Challenge}) => {
     const {t} = useTranslation("challenges")
     const {theme} = useThemeContext()
-    const space: number = 1 //8px
+    const space: number = 2 //8px
     return <Link to={"/desafio/" + challenge.id}>
-        <Stack width={100 + space * 2 * 8}>
+        <Stack alignItems="center" width={100 + space * 2 * 8}>
             <PBCard><ChallengeCover challenge={challenge}/></PBCard>
             <Typography align="center" lineHeight={1}
-                style={{ marginLeft: theme.spacing(space), marginRight: theme.spacing(space), marginBottom: theme.spacing(2)}}>
+                style={{ marginLeft: theme.spacing(space), marginRight: theme.spacing(space), marginBottom: theme.spacing(1)}}>
                     {t(`${challenge.id}.title`)}
             </Typography>
         </Stack>


### PR DESCRIPTION
Fixes https://github.com/Program-AR/pilas-bloques/issues/1535

- Ahora se ve mejor en los celus.
- Acortamos nombres que eran largos y se superponían entre sí
- Agregamos márgenes para que no se superpongan los nombres
- El dibujando ahora tiene título de grupo

(Izquierda viejo, derecha nuevo)
![image](https://github.com/Program-AR/pilas-bloques-react/assets/11671943/fa3d49a4-b514-460c-bf4b-7ec8dc846e9b)
(Izquierda viejo, derecha nuevo)

![image](https://github.com/Program-AR/pilas-bloques-react/assets/11671943/5f37a302-6799-42c3-a178-75646b0743cc)


(Izquierda viejo, derecha nuevo - en celus)

![image](https://github.com/Program-AR/pilas-bloques-react/assets/11671943/9dc82186-c09d-4012-b894-2077c1b32727)

