### PR TITLE
Botones de carga/descarga/borrado de solución

### DIFF
--- a/locales/en-us/challenge.json
+++ b/locales/en-us/challenge.json
@@ -22,5 +22,10 @@
     "tooltip": "Restart execution"
   },
   "multipleScenarios": "There are multiple scenarios!",
-  "close": "Close"
+  "close": "Close",
+  "solutionButtons": {
+    "download": "Download solution to your computer",
+    "upload": "Upload solution from your computer",
+    "clear": "Clear the current solution"
+  }
 }

--- a/locales/en-us/challenge.json
+++ b/locales/en-us/challenge.json
@@ -24,8 +24,8 @@
   "multipleScenarios": "There are multiple scenarios!",
   "close": "Close",
   "solutionButtons": {
-    "download": "Download solution to your computer",
-    "upload": "Upload solution from your computer",
+    "download": "Download solution",
+    "upload": "Upload solution",
     "clear": "Clear the current solution",
     "clearModal": {
       "warning": "Be careful! If you delete your solution, you will lose your work.",

--- a/locales/en-us/challenge.json
+++ b/locales/en-us/challenge.json
@@ -26,6 +26,10 @@
   "solutionButtons": {
     "download": "Download solution to your computer",
     "upload": "Upload solution from your computer",
-    "clear": "Clear the current solution"
+    "clear": "Clear the current solution",
+    "clearModal": {
+      "warning": "Be careful! If you delete your solution, you will lose your work.",
+      "button": "DELETE SOLUTION"
+    }
   }
 }

--- a/locales/es-ar/challenge.json
+++ b/locales/es-ar/challenge.json
@@ -22,5 +22,10 @@
     "tooltip": "Reiniciar la ejecución"
   },
   "multipleScenarios": "¡Hay varios escenarios!",
-  "close": "Cerrar"
+  "close": "Cerrar",
+  "solutionButtons": {
+    "download": "Descargar solución a tu computadora",
+    "upload": "Subir solución desde tu computadora",
+    "clear": "Borrar la solución actual"
+  }
 }

--- a/locales/es-ar/challenge.json
+++ b/locales/es-ar/challenge.json
@@ -26,6 +26,10 @@
   "solutionButtons": {
     "download": "Descargar solución a tu computadora",
     "upload": "Subir solución desde tu computadora",
-    "clear": "Borrar la solución actual"
+    "clear": "Borrar la solución actual",
+    "clearModal": {
+      "warning": "¡Cuidado! Al borrar la solución se perderan tus cambios.",
+      "button": "BORRAR LA SOLUCIÓN"
+    }
   }
 }

--- a/locales/es-ar/challenge.json
+++ b/locales/es-ar/challenge.json
@@ -24,8 +24,8 @@
   "multipleScenarios": "¡Hay varios escenarios!",
   "close": "Cerrar",
   "solutionButtons": {
-    "download": "Descargar solución a tu computadora",
-    "upload": "Subir solución desde tu computadora",
+    "download": "Descargar solución",
+    "upload": "Cargar solución",
     "clear": "Borrar la solución actual",
     "clearModal": {
       "warning": "¡Cuidado! Al borrar la solución se perderan tus cambios.",

--- a/locales/pt-br/challenge.json
+++ b/locales/pt-br/challenge.json
@@ -26,6 +26,10 @@
   "solutionButtons": {
     "download": "Baixe a solução para o seu computador",
     "upload": "Carregar solução do seu computador",
-    "clear": "Exclua a solução atual"
+    "clear": "Exclua a solução atual",
+    "clearModal": {
+      "warning": "Atenção! Remover a solução perderá suas alterações.",
+      "button": "REMOVER A SOLUÇÃO"
+    }
   }
 }

--- a/locales/pt-br/challenge.json
+++ b/locales/pt-br/challenge.json
@@ -22,5 +22,10 @@
     "tooltip": "Reiniciar execução"
   },
   "multipleScenarios": "Existem vários cenários!",
-  "close": "Fechar"
+  "close": "Fechar",
+  "solutionButtons": {
+    "download": "Baixe a solução para o seu computador",
+    "upload": "Carregar solução do seu computador",
+    "clear": "Exclua a solução atual"
+  }
 }

--- a/locales/pt-br/challenge.json
+++ b/locales/pt-br/challenge.json
@@ -24,8 +24,8 @@
   "multipleScenarios": "Existem vários cenários!",
   "close": "Fechar",
   "solutionButtons": {
-    "download": "Baixe a solução para o seu computador",
-    "upload": "Carregar solução do seu computador",
+    "download": "Baixe a solução",
+    "upload": "Carregar solução",
     "clear": "Exclua a solução atual",
     "clearModal": {
       "warning": "Atenção! Remover a solução perderá suas alterações.",

--- a/src/components/challengeView/ChallengeView.tsx
+++ b/src/components/challengeView/ChallengeView.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ChallengeBreadcrumb } from "./ChallengeBreadcrumb";
 import Blockly from "blockly/core"
 import { xmlBloqueEmpezarAEjecutar } from "../blockly/blockly";
+import { SolutionButtons } from "./SolutionButtons";
 
 export const serializedSceneToDescriptor = (scene: Scene) => {
   const mapToString = (map: SceneMap) => `"${JSON.stringify(map).replace(/"/g, '')}"`
@@ -118,11 +119,14 @@ type EditableBlocklyWorkspaceProps = {
 
 const HorizontalChallengeWorkspace = ({ challenge, blocklyWorkspaceProps }: ChallengeWorkspaceDistributionProps) => {
   const blocklyWorkspace = useMemo<JSX.Element>(() => {
-    return <EditableBlocklyWorkspace blockIds={blocklyWorkspaceProps.blockIds} categorized={blocklyWorkspaceProps.categorized} initialXml={blocklyWorkspaceProps.initialXml} isVertical={false} zoomScale={1.0}/>
+    return <EditableBlocklyWorkspace blockIds={blocklyWorkspaceProps.blockIds} categorized={blocklyWorkspaceProps.categorized} initialXml={blocklyWorkspaceProps.initialXml} isVertical={false} zoomScale={1.0} />
   }, [])
 
-  return <Stack direction="row" flexWrap={"wrap"} flexGrow={1}>
-    {blocklyWorkspace}
+  return <Stack direction="row" >
+    <Stack direction="row" position="relative" flexWrap={"wrap"} flexGrow={1}>
+      <SolutionButtons/>
+      {blocklyWorkspace}
+    </Stack>
     <Stack>
       <SceneButtons challenge={challenge} />
       <SceneView descriptor={challenge.sceneDescriptor} />
@@ -135,7 +139,7 @@ const VerticalChallengeWorkspace = ({ challenge, blocklyWorkspaceProps }: Challe
   const [openDrawer, setOpenDrawer] = useState<boolean>(false)
 
   const blocklyWorkspace = useMemo<JSX.Element>(() => {
-    return <EditableBlocklyWorkspace blockIds={blocklyWorkspaceProps.blockIds} categorized={blocklyWorkspaceProps.categorized} initialXml={blocklyWorkspaceProps.initialXml} isVertical={true} zoomScale={0.7}/>
+    return <EditableBlocklyWorkspace blockIds={blocklyWorkspaceProps.blockIds} categorized={blocklyWorkspaceProps.categorized} initialXml={blocklyWorkspaceProps.initialXml} isVertical={true} zoomScale={0.7} />
   }, [])
 
   return <Stack flexWrap={"wrap"} flexGrow={1} >

--- a/src/components/challengeView/EditableBlocklyWorkspace.tsx
+++ b/src/components/challengeView/EditableBlocklyWorkspace.tsx
@@ -7,7 +7,7 @@ type EditableBlocklyWorkspaceProps = {
 
 export const EditableBlocklyWorkspace = ({ blockIds, categorized, sx, isVertical, zoomScale, ...props }: PBBlocklyWorkspaceProps & EditableBlocklyWorkspaceProps) => {
     return <PBBlocklyWorkspace
-        sx={{ flexGrow: 1}}
+        sx={{ flexGrow: 1, zIndex: 5}}
         blockIds={blockIds}
         categorized={categorized}
         initialXml={xmlBloqueEmpezarAEjecutar}

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -1,4 +1,4 @@
-import { IconButton, IconButtonProps, Stack, Tooltip } from "@mui/material"
+import { Button, Dialog, DialogContent, DialogTitle, IconButton, IconButtonProps, Stack, Tooltip, Typography } from "@mui/material"
 import DownloadIcon from '@mui/icons-material/Download';
 import ClearIcon from '@mui/icons-material/Clear';
 import { useThemeContext } from "../../theme/ThemeContext";
@@ -7,6 +7,7 @@ import Blockly, { Block } from "blockly/core"
 import { LocalStorage } from "../../localStorage";
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import { xmlBloqueEmpezarAEjecutar } from "../blockly/blockly";
+import { useState } from "react";
 
 export const SolutionButtons = () => {
     const { t } = useTranslation('challenge')
@@ -87,11 +88,47 @@ const SaveSolutionButton = () => {
 const ClearSolutionButton = () => {
     const { t } = useTranslation('challenge')
 
-    const handleClick = () => {
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false)
+
+    const deleteSolution = () => {
         Blockly.getMainWorkspace().clear()
         const xmlDom = Blockly.utils.xml.textToDom(xmlBloqueEmpezarAEjecutar)
         Blockly.Xml.domToWorkspace(xmlDom, Blockly.getMainWorkspace())
+        setDeleteDialogOpen(false)
     }
 
-    return <SolutionButton onClick={handleClick} icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
+    const handleClick = () => {
+        setDeleteDialogOpen(true)
+    }
+
+    const handleClose = () => {
+        setDeleteDialogOpen(false)
+    }
+
+    return <>
+        <Dialog open={deleteDialogOpen} onClose={handleClose}>
+            <DialogTitle display="flex" justifyContent="flex-end">
+                <IconButton onClick={handleClose}>
+                    <ClearIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent >
+                <Stack justifyContent="center" alignContent="center">
+                    <Typography>{t("solutionButtons.clearModal.warning")}</Typography>
+                    <Button onClick={deleteSolution}
+                        sx={{
+                            fontWeight: 'bold',
+                            margin: 1,
+                            width: "auto",
+                            alignSelf: "center",
+                            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.2)',
+                        }}>
+                        {t("solutionButtons.clearModal.button")}
+                    </Button>
+                </Stack>
+            </DialogContent>
+        </Dialog>
+
+        <SolutionButton onClick={handleClick} icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
+    </>
 }

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -1,0 +1,33 @@
+import { IconButton, IconButtonProps, Stack } from "@mui/material"
+import DownloadIcon from '@mui/icons-material/Download';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import ClearIcon from '@mui/icons-material/Clear';
+import { useThemeContext } from "../../theme/ThemeContext";
+
+export const SolutionButtons = () => {
+    return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={1}>
+        <SolutionButton icon={<FileUploadIcon />}/>
+        <SolutionButton icon={<DownloadIcon />}/>
+        <SolutionButton icon={<ClearIcon />}/>
+    </Stack >
+}
+
+type SolucionButtonProps = {
+    icon: React.ReactNode
+}
+
+const SolutionButton = (props: SolucionButtonProps & IconButtonProps) => {
+    const { theme } = useThemeContext()
+
+    return <IconButton
+        {...props}
+        sx={{
+            backgroundColor: theme.palette.background.default,
+            color: theme.palette.text.primary,
+            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.2)',
+            borderRadius: '50%',
+        }}
+    >
+        {props.icon}
+    </IconButton>
+}

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -1,33 +1,40 @@
-import { IconButton, IconButtonProps, Stack } from "@mui/material"
+import { IconButton, IconButtonProps, Stack, Tooltip } from "@mui/material"
 import DownloadIcon from '@mui/icons-material/Download';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
 import ClearIcon from '@mui/icons-material/Clear';
 import { useThemeContext } from "../../theme/ThemeContext";
+import { useTranslation } from "react-i18next";
 
 export const SolutionButtons = () => {
+    const { t } = useTranslation('challenge')
+
     return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={1}>
-        <SolutionButton icon={<FileUploadIcon />}/>
-        <SolutionButton icon={<DownloadIcon />}/>
-        <SolutionButton icon={<ClearIcon />}/>
+        <SolutionButton icon={<FileUploadIcon />} tooltip={t("solutionButtons.upload")} />
+        <SolutionButton icon={<DownloadIcon />} tooltip={t("solutionButtons.download")} />
+        <SolutionButton icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
     </Stack >
 }
 
 type SolucionButtonProps = {
-    icon: React.ReactNode
+    icon: React.ReactNode,
+    tooltip: string
 }
 
 const SolutionButton = (props: SolucionButtonProps & IconButtonProps) => {
     const { theme } = useThemeContext()
 
-    return <IconButton
-        {...props}
-        sx={{
-            backgroundColor: theme.palette.background.default,
-            color: theme.palette.text.primary,
-            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.2)',
-            borderRadius: '50%',
-        }}
-    >
-        {props.icon}
-    </IconButton>
+    return <Tooltip title={props.tooltip}>
+        <IconButton
+            {...props}
+            sx={{
+                backgroundColor: theme.palette.background.default,
+                color: theme.palette.text.primary,
+                boxShadow: '0 2px 6px rgba(0, 0, 0, 0.2)',
+                borderRadius: '50%',
+            }}
+        >
+            {props.icon}
+        </IconButton>
+    </Tooltip>
+
 }

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -11,8 +11,8 @@ import { ChangeEvent, useRef, useState } from "react";
 
 export const SolutionButtons = () => {
     return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={2}>
-        <SaveSolutionButton />
         <UploadSolution />
+        <SaveSolutionButton />
         <ClearSolutionButton />
     </Stack >
 }
@@ -120,6 +120,7 @@ const ClearSolutionButton = () => {
                             width: "auto",
                             alignSelf: "center",
                             boxShadow: '0 2px 6px rgba(0, 0, 0, 0.2)',
+                            color: 'red'
                         }}>
                         {t("solutionButtons.clearModal.button")}
                     </Button>

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -7,14 +7,12 @@ import Blockly, { Block } from "blockly/core"
 import { LocalStorage } from "../../localStorage";
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import { xmlBloqueEmpezarAEjecutar } from "../blockly/blockly";
-import { useState } from "react";
+import { ChangeEvent, useRef, useState } from "react";
 
 export const SolutionButtons = () => {
-    const { t } = useTranslation('challenge')
-
     return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={2}>
         <SaveSolutionButton />
-        <SolutionButton icon={<DriveFolderUploadIcon />} tooltip={t("solutionButtons.upload")} />
+        <UploadSolution />
         <ClearSolutionButton />
     </Stack >
 }
@@ -43,7 +41,7 @@ const SolutionButton = (props: SolucionButtonProps & IconButtonProps) => {
 
 }
 
-const SPBQ_FILE_VERSION = 1
+const SPBQ_FILE_VERSION = 2
 
 const SaveSolutionButton = () => {
     const { t } = useTranslation('challenge')
@@ -130,5 +128,40 @@ const ClearSolutionButton = () => {
         </Dialog>
 
         <SolutionButton onClick={handleClick} icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
+    </>
+}
+
+const UploadSolution = () => {
+    const { t } = useTranslation('challenge')
+
+    const fileInputRef = useRef<HTMLInputElement>(null)
+
+    const handleClick = () => {
+        fileInputRef.current?.click()
+    }
+
+    const handleOpenFile = async (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+
+        if (!file) return
+
+        const text = await file.text()
+        const solution = atob(JSON.parse(text).solucion)
+
+        Blockly.getMainWorkspace().clear()
+        const xmlDom = Blockly.utils.xml.textToDom(solution)
+        Blockly.Xml.domToWorkspace(xmlDom, Blockly.getMainWorkspace())
+    }
+
+
+    return <>
+        <SolutionButton icon={<DriveFolderUploadIcon />} tooltip={t("solutionButtons.upload")} onClick={handleClick} />
+        <input
+            type="file"
+            accept=".spbq"
+            ref={fileInputRef}
+            onChange={handleOpenFile}
+            style={{ display: "none" }}
+        />
     </>
 }

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -1,16 +1,18 @@
 import { IconButton, IconButtonProps, Stack, Tooltip } from "@mui/material"
 import DownloadIcon from '@mui/icons-material/Download';
-import FileUploadIcon from '@mui/icons-material/FileUpload';
 import ClearIcon from '@mui/icons-material/Clear';
 import { useThemeContext } from "../../theme/ThemeContext";
 import { useTranslation } from "react-i18next";
+import Blockly, { Block } from "blockly/core"
+import { LocalStorage } from "../../localStorage";
+import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 
 export const SolutionButtons = () => {
     const { t } = useTranslation('challenge')
 
-    return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={1}>
-        <SolutionButton icon={<FileUploadIcon />} tooltip={t("solutionButtons.upload")} />
-        <SolutionButton icon={<DownloadIcon />} tooltip={t("solutionButtons.download")} />
+    return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={2}>
+        <SaveSolutionButton />
+        <SolutionButton icon={<DriveFolderUploadIcon />} tooltip={t("solutionButtons.upload")} />
         <SolutionButton icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
     </Stack >
 }
@@ -37,4 +39,46 @@ const SolutionButton = (props: SolucionButtonProps & IconButtonProps) => {
         </IconButton>
     </Tooltip>
 
+}
+
+const SPBQ_FILE_VERSION = 1
+
+const SaveSolutionButton = () => {
+    const { t } = useTranslation('challenge')
+
+    const sanatizedTitle = () => LocalStorage.getCreatorChallenge()?.title
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-zA-Z0-9 ]/g, '')
+        .trim()
+        .split(/\s+/)
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join('');
+
+    const activityName = sanatizedTitle() || "SinTitulo"
+
+    const fileName = `${activityName}.spbq`;
+
+    const downloadFile = (text: string, name: string, type: string) => {
+        const file = new Blob([text], { type: type });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(file);
+        a.download = name;
+        a.type = type;
+        a.click();
+    }
+
+    const handleClick = () => {
+        const xml = Blockly.utils.xml.domToText(Blockly.Xml.workspaceToDom(Blockly.getMainWorkspace()))
+
+        const content = {
+            version: SPBQ_FILE_VERSION,
+            actividad: activityName,
+            solucion: btoa(xml)
+        };
+
+        downloadFile(JSON.stringify(content), fileName, 'application/octet-stream');
+    }
+
+    return <SolutionButton onClick={handleClick} icon={<DownloadIcon />} tooltip={t("solutionButtons.download")} />
 }

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import Blockly, { Block } from "blockly/core"
 import { LocalStorage } from "../../localStorage";
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
+import { xmlBloqueEmpezarAEjecutar } from "../blockly/blockly";
 
 export const SolutionButtons = () => {
     const { t } = useTranslation('challenge')
@@ -13,7 +14,7 @@ export const SolutionButtons = () => {
     return <Stack sx={{ position: "absolute", zIndex: 10, right: 15, top: 15 }} direction="row" spacing={2}>
         <SaveSolutionButton />
         <SolutionButton icon={<DriveFolderUploadIcon />} tooltip={t("solutionButtons.upload")} />
-        <SolutionButton icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
+        <ClearSolutionButton />
     </Stack >
 }
 
@@ -81,4 +82,16 @@ const SaveSolutionButton = () => {
     }
 
     return <SolutionButton onClick={handleClick} icon={<DownloadIcon />} tooltip={t("solutionButtons.download")} />
+}
+
+const ClearSolutionButton = () => {
+    const { t } = useTranslation('challenge')
+
+    const handleClick = () => {
+        Blockly.getMainWorkspace().clear()
+        const xmlDom = Blockly.utils.xml.textToDom(xmlBloqueEmpezarAEjecutar)
+        Blockly.Xml.domToWorkspace(xmlDom, Blockly.getMainWorkspace())
+    }
+
+    return <SolutionButton onClick={handleClick} icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
 }


### PR DESCRIPTION
Resolves #241 
Resolves https://github.com/Program-AR/pilas-bloques-app/issues/224

https://github.com/user-attachments/assets/de3dab9c-73a9-43dc-adeb-1f72fa9b0f5f

Cosas pendientes que no llegué a hacer :cry::

- [ ] Tests
- [ ] Manejo de errores:
   - [ ] Si el archivo no es spbq o no tiene un xml dentro
   - [ ] en la carga de solución, si es de una versión vieja (otro `SPBQ_FILE_VERSION`) o bien es de otro desafío, debería aparecer un cartel que diga:

![imagen](https://github.com/user-attachments/assets/3b9d5aa7-59f2-4c39-a7ac-07e7c3edcaef)

- [ ] Pantalla vertical:
  - [ ] Hablamos de dejar los botones arriba pero de forma vertical, quizás tener un botón que al apretarlo te extienda estos botones.
  - [ ] El tachito que viene con blockly hay que ver si se puede bajar a la esquina derecha en lugar de donde está ahora (esquina derecha pero está arriba)


