### PR TITLE
Border radius en pantalla de desafio

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,3 +15,7 @@ html, body, #root {
 a {
     text-decoration: none;
 }
+
+.injectionDiv {
+  border-radius: 10px !important;
+}


### PR DESCRIPTION
Me molestaba que en la nueva pantalla de desafio, el blockly se viera cuadrado en lugar de redondo como el resto de los componentes:
![imagen](https://github.com/user-attachments/assets/a23deae5-1d06-418f-b3a9-69ca21822e82)

Ahora se ve así:
![imagen](https://github.com/user-attachments/assets/b4ea7ec7-5727-4327-aae3-e65c066fe920)

Esta es una solución rápida pero tiene el problema de que no está usando el border-radius que viene en el theme si no que lo tiene hardcodeado, asi que es una solución provisoria.