### PR TITLE
Lógica para mantener el "reiniciar" cuando termina la ejecución

### DIFF
--- a/src/components/challengeView/SceneButtons/Execute.tsx
+++ b/src/components/challengeView/SceneButtons/Execute.tsx
@@ -6,7 +6,6 @@ import { Challenge } from "../../../staticData/challenges"
 import { useTranslation } from "react-i18next"
 import { EndDialog } from "./EndChallengeDialog"
 import { useInterpreterRunner } from "./useInterpreterRunner"
-import { useState } from "react"
 
 type ExecuteButtonProps = {
   challenge: Challenge
@@ -20,34 +19,14 @@ export const ExecuteButton = ({ challenge, running, setRunning, interpreterVersi
 
   const { isSmallScreen } = useThemeContext()
   const { t } = useTranslation('challenge')
-  const [hasFinished, setHasFinished] = useState(false);
 
   const { run, showModal, setShowModal } = useInterpreterRunner(challenge, setRunning, 'run', interpreterVersion);
 
-  const handleRun = async () => {
-    setHasFinished(false);
-    setRunning!(true);
-    await run();
-    // Marcar que terminó pero no cambiar running a false
-    setHasFinished(true);
-  };
-
-  const handleRestart = () => {
-    if (onRestart) {
-      onRestart();
-    }
-    setHasFinished(false);
-    setRunning!(false);
-  };
-
-  // Determinar qué estado mostrar
-  const showRestartState = running || hasFinished;
-
   return <>
-    {showRestartState ? (
+    {running ? (
       <Tooltip title={t('restart.tooltip')}>
         {isSmallScreen ?
-          <IconButton className={styles['icon-button']} onClick={handleRestart}
+          <IconButton className={styles['icon-button']} onClick={onRestart}
             data-testid='execute-button' data-finishedexecution={false}>
             <Stack>
               <Circle color='secondary' className={styles['circle-icon']} />
@@ -57,19 +36,19 @@ export const ExecuteButton = ({ challenge, running, setRunning, interpreterVersi
           :
           <Button className={styles['scene-button']}
             sx={{ color: '#fff' }}
-            startIcon={<ReplayOutlined />} variant="contained" color="secondary" onClick={handleRestart} data-finishedexecution={false} data-testid='execute-button'>{t("restart.label")} </Button>
+            startIcon={<ReplayOutlined />} variant="contained" color="secondary" onClick={onRestart} data-finishedexecution={false} data-testid='execute-button'>{t("restart.label")} </Button>
         }
       </Tooltip>) : (
       <Tooltip title={t('run.tooltip')}>
         {isSmallScreen ?
-          <IconButton className={styles['icon-button']} onClick={handleRun} data-testid='execute-button' data-finishedexecution={true}>
+          <IconButton className={styles['icon-button']} onClick={run} data-testid='execute-button' data-finishedexecution={true}>
             <Stack>
               <Circle color='success' className={styles['circle-icon']} />
               <PlayArrow className={styles['icon']} />
             </Stack>
           </IconButton >
           :
-          <Button className={styles['scene-button']} startIcon={<PlayArrow />} variant="contained" color="success" onClick={handleRun} data-finishedexecution={true} data-testid='execute-button'>{t("run.label")} </Button>
+          <Button className={styles['scene-button']} startIcon={<PlayArrow />} variant="contained" color="success" onClick={run} data-finishedexecution={true} data-testid='execute-button'>{t("run.label")} </Button>
         }
       </Tooltip>
     )}

--- a/src/components/challengeView/SceneButtons/Execute.tsx
+++ b/src/components/challengeView/SceneButtons/Execute.tsx
@@ -6,6 +6,7 @@ import { Challenge } from "../../../staticData/challenges"
 import { useTranslation } from "react-i18next"
 import { EndDialog } from "./EndChallengeDialog"
 import { useInterpreterRunner } from "./useInterpreterRunner"
+import { useState } from "react"
 
 type ExecuteButtonProps = {
   challenge: Challenge
@@ -19,14 +20,32 @@ export const ExecuteButton = ({ challenge, running, setRunning, interpreterVersi
 
   const { isSmallScreen } = useThemeContext()
   const { t } = useTranslation('challenge')
+  const [hasFinished, setHasFinished] = useState(false);
 
   const { run, showModal, setShowModal } = useInterpreterRunner(challenge, setRunning, 'run', interpreterVersion);
 
+  const handleRun = async () => {
+    setHasFinished(false);
+    setRunning!(true);
+    await run();
+    setHasFinished(true);
+  };
+
+  const handleRestart = () => {
+    if (onRestart) {
+      onRestart();
+    }
+    setHasFinished(false);
+    setRunning!(false);
+  };
+
+  const showRestartState = running || hasFinished;
+
   return <>
-    {running ? (
+    {showRestartState ? (
       <Tooltip title={t('restart.tooltip')}>
         {isSmallScreen ?
-          <IconButton className={styles['icon-button']} onClick={onRestart}
+          <IconButton className={styles['icon-button']} onClick={handleRestart}
             data-testid='execute-button' data-finishedexecution={false}>
             <Stack>
               <Circle color='secondary' className={styles['circle-icon']} />
@@ -36,19 +55,19 @@ export const ExecuteButton = ({ challenge, running, setRunning, interpreterVersi
           :
           <Button className={styles['scene-button']}
             sx={{ color: '#fff' }}
-            startIcon={<ReplayOutlined />} variant="contained" color="secondary" onClick={onRestart} data-finishedexecution={false} data-testid='execute-button'>{t("restart.label")} </Button>
+            startIcon={<ReplayOutlined />} variant="contained" color="secondary" onClick={handleRestart} data-finishedexecution={false} data-testid='execute-button'>{t("restart.label")} </Button>
         }
       </Tooltip>) : (
       <Tooltip title={t('run.tooltip')}>
         {isSmallScreen ?
-          <IconButton className={styles['icon-button']} onClick={run} data-testid='execute-button' data-finishedexecution={true}>
+          <IconButton className={styles['icon-button']} onClick={handleRun} data-testid='execute-button' data-finishedexecution={true}>
             <Stack>
               <Circle color='success' className={styles['circle-icon']} />
               <PlayArrow className={styles['icon']} />
             </Stack>
           </IconButton >
           :
-          <Button className={styles['scene-button']} startIcon={<PlayArrow />} variant="contained" color="success" onClick={run} data-finishedexecution={true} data-testid='execute-button'>{t("run.label")} </Button>
+          <Button className={styles['scene-button']} startIcon={<PlayArrow />} variant="contained" color="success" onClick={handleRun} data-finishedexecution={true} data-testid='execute-button'>{t("run.label")} </Button>
         }
       </Tooltip>
     )}


### PR DESCRIPTION
Cuando terminaba la ejecución quedaba el personaje en la última posición del programa y el botón se ponía de vuelta en "ejecutar". Quedaba raro porque no había forma de reiniciar el tablero sin que comenzara de nuevo la ejecución.

[Grabación de pantalla desde 2025-08-20 01-20-53.webm](https://github.com/user-attachments/assets/3bf3a6d0-61db-49d7-b7bb-26bda7343a00)
