### PR TITLE
cambio icono 'borrar la solucion actual'

### DIFF
--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -1,6 +1,7 @@
 import { Button, Dialog, DialogContent, DialogTitle, IconButton, IconButtonProps, Stack, Tooltip, Typography } from "@mui/material"
 import DownloadIcon from '@mui/icons-material/Download';
 import ClearIcon from '@mui/icons-material/Clear';
+import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
 import { useThemeContext } from "../../theme/ThemeContext";
 import { useTranslation } from "react-i18next";
 import Blockly from "blockly/core"
@@ -137,7 +138,7 @@ const ClearSolutionButton = () => {
       </DialogContent>
     </Dialog>
 
-    <SolutionButton onClick={handleClick} icon={<ClearIcon />} tooltip={t("solutionButtons.clear")} />
+    <SolutionButton onClick={handleClick} icon={<CleaningServicesIcon />} tooltip={t("solutionButtons.clear")} />
   </>
 }
 


### PR DESCRIPTION
Resolves #344 

En el menu desplegable de los botones del workspace nos quedaron dos "X" lo cual es confuso. Se cambió el icono del botón para borrar la solución actual:

* En la pantalla horinzontal:
  
    | Antes  | Ahora   |
    | ------- | -------- |
    | <img width="1884" height="862" alt="Captura de pantalla 2026-05-22 121644" src="https://github.com/user-attachments/assets/97cd875f-2ca1-41ba-96b6-3cabeb44d8a9" />|<img width="1895" height="870" alt="Captura de pantalla 2026-05-22 121338" src="https://github.com/user-attachments/assets/02f1f8cf-a187-47e6-8099-f513b48b4381" />|
    
  * En la pantalla vertical:
  
    | Antes  | Ahora   |
    | ------- | -------- |
    |<img width="1080" height="1964" alt="antes-vertical" src="https://github.com/user-attachments/assets/ba98abbc-9e69-4ef5-8123-bf3339e6b14e" />|<img width="1080" height="1955" alt="despues-vertical" src="https://github.com/user-attachments/assets/4f860a57-b480-476d-be34-f25808055afc" />|

