### PR TITLE
Definicion de executionFinishedEvent  y  su test.

### DIFF
--- a/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
+++ b/src/components/challengeView/SceneButtons/useInterpreterRunner.ts
@@ -70,10 +70,8 @@ export const useInterpreterRunner = (
           interpreterRef.current = null;
           setStepping(false);
           checkProblemSolved().then(async (solved) => {
-            // TODO: Enviar staticAnalysis y executionResult como lo hace Ember
             const staticAnalysis = { couldExecute: true };
-            const executionResult = { solved };
-            if (solutionId) await PilasBloquesApi.executionFinished(solutionId, staticAnalysis, executionResult);
+            if (solutionId) await PilasBloquesApi.executionFinishedEvent(solutionId, staticAnalysis, solved);
             resolve();
           });
         }

--- a/src/pbApi.ts
+++ b/src/pbApi.ts
@@ -114,6 +114,13 @@ export namespace PilasBloquesApi{
       await _send('PUT', `solutions/${solutionId}`, { staticAnalysis, executionResult }, false).catch(logger('executionFinished'))
     }
 
+    export const executionFinishedEvent = async (solutionId: string, staticAnalysis: any, isTheProblemSolved: boolean, executionResult: any = {}) => {
+      await executionFinished(solutionId, staticAnalysis, {
+        isTheProblemSolved,
+        ...executionResult
+      })
+    }
+
     export const passwordRecovery = async (userIdentifier: string) => {
       return await _send('POST', `password-recovery?userIdentifier=${userIdentifier}`)
     }

--- a/src/test/unit/pbApi.test.ts
+++ b/src/test/unit/pbApi.test.ts
@@ -75,5 +75,16 @@ describe('PB Api', () => {
         mockApiPath('login', { body: "SERVER ERROR", status: 400 })
         expect(async () => {await PilasBloquesApi.login(credentials)}).rejects.toThrow("SERVER ERROR")
     })
+
+    test('executionFinishedEvent should call executionFinished with merged executionResult', async () => {
+       
+        fetchMock.put(`${PilasBloquesApi.baseURL}/solutions/sol-123`, 200)
+
+        await PilasBloquesApi.executionFinishedEvent('sol-123', { couldExecute: true }, true, { duration: 42 })
+
+        const body = fetchCallBody()
+        
+        expect(body.executionResult).toMatchObject({ isTheProblemSolved: true, duration: 42 })
+    })
 })
 


### PR DESCRIPTION
Resolves #258 

Se creó la función `executionFinishedEvent` la cual actúa como un wrapper alrededor de la función `executionFinished`.  Recibe cuatro parámetros: un string `solutionId` para identidicar la solución, un objeto `staticAnalysis` que contiene los resultados del análisis de código, un booleano `isTheProblemSolved` que indica si el desafío fue resuelto, y un objeto `executionResult` opcional (por defecto un objeto vacío) para cualquier metadata adicional de la ejecución.

La responsabilidad principal de la función es normalizar el formato de datos antes de delegar el trabajo a `executionFinished`. En lugar de requerir que los callers construyan manualmente el objeto `executionResult` incluyendo ya la propiedad `isTheProblemSolved`, este wrapper acepta el booleano como un parámetro separado.

Internamente, la función invoca `await executionFinished(solutionId, staticAnalysis, {...})`, pasando el ID de solución y el análisis estático tal cual, pero fusionando el booleano `isTheProblemSolved` en un nuevo objeto de resultado de ejecución usando el operador `spread`. Esta operación de fusión `{ isTheProblemSolved, ...executionResult }` asegura que `isTheProblemSolved` siempre está presente en la carga final, mientras preserva cualquier propiedad adicional del parámetro `executionResult`.

 `executionFinished` es un mecanismo de reporte "dispara y olvida"—envía métricas de finalización al servidor sin interrumpir el flujo de trabajo del usuario si la red falla.

El test revisa si  `executionFinishedEvent` construye y envía una petición cuyo `executionResult` incluye correctamente la bandera `isTheProblemSolved` junto con los demás campos de resultado.