### PR TITLE
Ahora los bloques se ajustan correctamente al texto

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,3 +19,7 @@ a {
 .injectionDiv {
   border-radius: 10px !important;
 }
+
+.blocklyText, .blocklyHtmlInput {
+  text-transform: none !important;
+}

--- a/src/components/blockly/PBBlocklyWorkspace.tsx
+++ b/src/components/blockly/PBBlocklyWorkspace.tsx
@@ -20,9 +20,14 @@ export type PBBlocklyWorkspaceProps = {
 }
 
 export const PBBlocklyWorkspace = ({ blockIds, categorized, sx, title, ...props }: PBBlocklyWorkspaceProps) => {
-  const { t } = useTranslation("blocks")
+  const { t: originalT } = useTranslation("blocks")
 
-  const { blocklyTheme } = useThemeContext()
+  const { blocklyTheme, simpleReadModeEnabled } = useThemeContext()
+
+  const t = (key: string) => {
+    const translation = originalT(key);
+    return simpleReadModeEnabled && typeof translation === 'string' ? translation.toUpperCase() : translation;
+  }
 
   const [blocklyContainer, setBlocklyContainer] = useState<Element>()
 
@@ -30,7 +35,7 @@ export const PBBlocklyWorkspace = ({ blockIds, categorized, sx, title, ...props 
 
   const toolbox: Toolbox = categorized ? categorizedToolbox(t, blocksWithCategories) : uncategorizedToolbox(blocksWithCategories)
 
-  setupBlocklyBlocks(t)
+  setupBlocklyBlocks(t, simpleReadModeEnabled)
 
   if (blocklyContainer) setupBlockly(blocklyContainer, { theme: blocklyTheme, toolbox, ...props.workspaceConfiguration } )
 

--- a/src/components/blockly/blockly.ts
+++ b/src/components/blockly/blockly.ts
@@ -10,7 +10,6 @@ import { createValueBlocks } from "./blocksGallery/values";
 import { createControlStructureBlocks } from "./blocksGallery/controlStructures";
 import { createFirstBlock, createOthersBlocks } from "./blocksGallery/others";
 
-Blockly.setLocale(Es); // TODO: this needs to be taken from chosen intl
 
 export type BlocklyBlockDefinition = {
   type?: string
@@ -38,7 +37,16 @@ export const xmlBloqueEmpezarAEjecutar = `<xml xmlns="http://www.w3.org/1999/xht
               <block type="al_empezar_a_ejecutar" x="15" y="15"></block>
             </xml>`
 
-export const setupBlocklyBlocks = (t: (key: string) => string) => {
+export const setupBlocklyBlocks = (t: (key: string) => string, simpleReadModeEnabled: boolean = false) => {
+  if (simpleReadModeEnabled) {
+    const upperMsg: any = {};
+    for (const key in Es) {
+      upperMsg[key] = typeof (Es as any)[key] === 'string' ? (Es as any)[key].toUpperCase() : (Es as any)[key];
+    }
+    Blockly.setLocale(upperMsg);
+  } else {
+    Blockly.setLocale(Es);
+  }
 
   defineBlocklyTranslations(t)
 


### PR DESCRIPTION
Resolves #358 

Descripción del problema:
El error se presentaba al activar el "Modo de Lectura Simple". Esta función aplicaba un estilo global para transformar los textos a mayúsculas, pero la librería que renderiza los bloques (Blockly) calculaba el ancho del contenedor basándose en el texto original (en minúsculas) antes de que el navegador aplique el diseño visual. Como las mayúsculas ocupan más espacio físico en la pantalla, el bloque se dibujaba más corto de lo debido, provocando que el texto se desbordara y quedara fuera del margen.

Solución implementada:
Para resolverlo, se desactivó la transformación desde el CSS exclusivamente en los textos de los bloques y se pasó a gestionar la conversión directamente desde javascript. Ahora, cuando el modo de lectura simple está activo, el sistema intercepta los textos y se los entrega a la librería ya convertidos a mayúsculas desde el origen. De esta manera, el motor de renderizado calcula las dimensiones reales de entrada y los bloques se adaptan perfectamente al tamaño del texto.

Antes:
<img width="725" height="480" alt="611524320-b3160bd3-84e2-45fc-898f-f57d5f2284eb" src="https://github.com/user-attachments/assets/5e4be656-a1c1-462e-8afd-f82dd3fbcee0" />

Ahora:
<img width="1082" height="743" alt="image" src="https://github.com/user-attachments/assets/185f3bca-ff68-4c17-857d-d848043fc4b0" />
