### PR TITLE
Reubicar bloques

### DIFF
--- a/locales/en-us/blocks.json
+++ b/locales/en-us/blocks.json
@@ -137,7 +137,7 @@
     "backToLeftBorder": "Get back to the left border",
     "drawSide": "Draw a side of",
     "writeAnotherText": "Write text in another cel",
-    "rotateGrades": "Rotate grades",
+    "rotateGrades": "Rotate %1 grades",
     "isAVowel": "Is a vowel ?",
     "repeatEmpty": "Repeat",
     "JumpForward": "Jump forward", 

--- a/locales/es-ar/blocks.json
+++ b/locales/es-ar/blocks.json
@@ -136,7 +136,7 @@
     "backToLeftBorder": "Volver al borde izquierdo",
     "drawSide": "Dibujar lado",
     "writeAnotherText": "Escribir texto dado en otra cuadricula",
-    "rotateGrades": "Girar grados",
+    "rotateGrades": "Girar %1 grados",
     "isAVowel": "¿ Hay vocal ?",
     "repeatEmpty": "Repetir",
     "JumpForward": "Saltar hacia adelante",

--- a/src/components/blockly/blocks.ts
+++ b/src/components/blockly/blocks.ts
@@ -166,103 +166,11 @@ export const commonBlocks: BlockType[] = [
     id: 'PuedeMoverDerecha',
     intlId: 'canMoveRight',
     categoryId: 'sensors'
-  }
-]
-
-const notUsedBlocks: BlockType[] = [
-  {
-    id: 'SiguienteColumna',
-    intlId: 'nextColumn',
-    categoryId: 'primitives'
   },
   {
-    id: 'SiguienteFila',
-    intlId: 'nextLine',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SiguienteFilaTotal',
-    intlId: 'nextLine',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SaltarHaciaAdelante',
-    intlId: 'JumpForward',
-    categoryId: 'primitives',
-    toolboxJSON: {
-      "kind": "block",
-      "type": "SaltarHaciaAdelante",
-      "inputs": {
-        "longitud": {
-          "block": {
-            "type": "math_number",
-            "fields": {
-              "NUM": 100
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    id: 'EstoyEnEsquina',
-    intlId: 'atTheSquare',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'TocandoInicio',
-    intlId: 'atTheBeginning',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'RepetirVacio',
-    intlId: 'repeatEmpty',
-    categoryId: 'repetitions'
-  },
-  {
-    id: 'EstoySobreElFinalManic',
-    intlId: 'atColumnEnd',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'EstoySobreElInicioManic',
-    intlId: 'atColumnBeginning',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'ContarEstrella',
-    intlId: 'countStar',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'ContarPlaneta',
-    intlId: 'countPlanet',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'KmsTotales',
-    intlId: 'kmToTravel',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'ObservarConAmigos',
-    intlId: 'lookWithFriends',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'Avanzar1kmChuy',
-    intlId: 'move1Km',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SiguienteTelescopio',
-    intlId: 'moveNextTelescope',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'MoverTelescopio',
-    intlId: 'moveTelescope',
-    categoryId: 'primitives'
+    id: 'OpComparacion',
+    intlId: 'logic_compare',
+    categoryId: 'operators'
   },
 ]
 
@@ -721,6 +629,100 @@ const challengeOnlyBlocks: BlockType[] = [
     id: 'TocandoGuyra',
     intlId: 'guyraHere',
     categoryId: 'sensors'
+  },
+  {
+    id: 'SiguienteFila',
+    intlId: 'nextLine',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'TocandoInicio',
+    intlId: 'atTheBeginning',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'EstoyEnEsquina',
+    intlId: 'atTheSquare',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'ContarEstrella',
+    intlId: 'countStar',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'ContarPlaneta',
+    intlId: 'countPlanet',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EstoySobreElFinalManic',
+    intlId: 'atColumnEnd',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'EstoySobreElInicioManic',
+    intlId: 'atColumnBeginning',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'SiguienteColumna',
+    intlId: 'nextColumn',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'Avanzar1kmChuy',
+    intlId: 'move1Km',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'RepetirVacio',
+    intlId: 'repeatEmpty',
+    categoryId: 'repetitions'
+  },
+  {
+    id: 'KmsTotales',
+    intlId: 'kmToTravel',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'SaltarHaciaAdelante',
+    intlId: 'JumpForward',
+    categoryId: 'primitives',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "SaltarHaciaAdelante",
+      "inputs": {
+        "longitud": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 100
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    id: 'MoverTelescopio',
+    intlId: 'moveTelescope',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'ObservarConAmigos',
+    intlId: 'lookWithFriends',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'SiguienteFilaTotal',
+    intlId: 'nextLine',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'SiguienteTelescopio',
+    intlId: 'moveNextTelescope',
+    categoryId: 'primitives'
   }, 
 ]
 

--- a/src/components/blockly/blocks.ts
+++ b/src/components/blockly/blocks.ts
@@ -176,63 +176,8 @@ const notUsedBlocks: BlockType[] = [
     categoryId: 'primitives'
   },
   {
-    id: 'Retroceder',
-    intlId: 'back',
-    categoryId: 'primitives'
-  },
-  {
     id: 'SiguienteFila',
     intlId: 'nextLine',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'VolverABordeIzquierdo',
-    intlId: 'goToLeftBorder',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'Avanzar',
-    intlId: 'advance',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'EscribirA',
-    intlId: 'writeA',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'EscribirB',
-    intlId: 'writeB',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'EscribirC',
-    intlId: 'writeC',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'EscribirLetraActualEnOtraCuadricula',
-    intlId: 'writeLetter',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SaltarAbajo',
-    intlId: 'jumpDown',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SaltarArriba',
-    intlId: 'jumpUp',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SaltarDerecha',
-    intlId: 'jumpRight',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SaltarIzquierda',
-    intlId: 'jumpLeft',
     categoryId: 'primitives'
   },
   {
@@ -270,44 +215,9 @@ const notUsedBlocks: BlockType[] = [
     categoryId: 'sensors'
   },
   {
-    id: 'TocandoDerecha',
-    intlId: 'canMoveRight',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'TocandoAbajo',
-    intlId: 'canMoveDown',
-    categoryId: 'sensors'
-  },
-  {
     id: 'RepetirVacio',
     intlId: 'repeatEmpty',
     categoryId: 'repetitions'
-  },
-  {
-    id: 'EntregarPelota',
-    intlId: 'giveBall',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'MoverAbajoDibujando',
-    intlId: 'moveAndDrawDown',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'MoverArribaDibujando',
-    intlId: 'moveAndDrawUp',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'MoverDerechaDibujando',
-    intlId: 'moveAndDrawRight',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'MoverIzquierdaDibujando',
-    intlId: 'moveAndDrawLeft',
-    categoryId: 'primitives'
   },
   {
     id: 'EstoySobreElFinalManic',
@@ -320,16 +230,6 @@ const notUsedBlocks: BlockType[] = [
     categoryId: 'sensors'
   },
   {
-    id: 'RebotarPiePulpito',
-    intlId: 'bounceFootRubberBall',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'RebotarPingPong',
-    intlId: 'bouncePingPong',
-    categoryId: 'primitives'
-  },
-  {
     id: 'ContarEstrella',
     intlId: 'countStar',
     categoryId: 'primitives'
@@ -337,50 +237,6 @@ const notUsedBlocks: BlockType[] = [
   {
     id: 'ContarPlaneta',
     intlId: 'countPlanet',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'DibujarLado',
-    intlId: 'drawSide',
-    categoryId: 'primitives',
-    toolboxJSON: {
-      "kind": "block",
-      "type": "DibujarLado",
-      "inputs": {
-        "longitud": {
-          "block": {
-            "type": "math_number",
-            "fields": {
-              "NUM": 100
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    id: 'EntregarCargador',
-    intlId: 'giveCharger',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'EntregarTelescopio',
-    intlId: 'giveTelescope',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'IrseEnYacare',
-    intlId: 'goInAlligator',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'TocandoGuyra',
-    intlId: 'guyraHere',
-    categoryId: 'sensors'
-  },
-  {
-    id: 'InstalarJuego',
-    intlId: 'installGame',
     categoryId: 'primitives'
   },
   {
@@ -408,75 +264,6 @@ const notUsedBlocks: BlockType[] = [
     intlId: 'moveTelescope',
     categoryId: 'primitives'
   },
-  {
-    id: 'PasarASiguienteComputadora',
-    intlId: 'nextComputer',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'SubirPajarito',
-    intlId: 'pickBird',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'RecogerPulpito',
-    intlId: 'pickRubberBall',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'Colocar',
-    intlId: 'putIntoTheTrashBin',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'GirarGrados',
-    intlId: 'rotateGrades',
-    categoryId: 'primitives',
-    toolboxJSON: {
-      "kind": "block",
-      "type": "GirarGrados",
-      "inputs": {
-        "longitud": {
-          "block": {
-            "type": "math_number",
-            "fields": {
-              "NUM": 100
-            }
-          }
-        }
-      }
-    }
-  },
-  {
-    id: 'TomarLata',
-    intlId: 'takeCan',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'TomarPapel',
-    intlId: 'takePaper',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'AgarrarTelescopio',
-    intlId: 'takeTelescope',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'ApagarComputadora',
-    intlId: 'turnComputerOff',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'PrenderComputadora',
-    intlId: 'turnComputerOn',
-    categoryId: 'primitives'
-  },
-  {
-    id: 'RevolearPulpito',
-    intlId: 'volleyRubberBall',
-    categoryId: 'primitives'
-  }
 ]
 
 
@@ -701,6 +488,62 @@ export const sceneBlocks: BlockType[] = [
     intlId: 'bouncePingPong',
     categoryId: 'primitives'
   },
+  
+  
+]
+
+const challengeOnlyBlocks: BlockType[] = [
+  // bloques que deben existir en desafíos pero no en el selector del creador
+  {
+    id: 'MoverAbajoDibujando',
+    intlId: 'moveAndDrawDown',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'MoverArribaDibujando',
+    intlId: 'moveAndDrawUp',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'MoverDerechaDibujando',
+    intlId: 'moveAndDrawRight',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'MoverIzquierdaDibujando',
+    intlId: 'moveAndDrawLeft',
+    categoryId: 'primitives'
+  },
+    {
+    id: 'SaltarAbajo',
+    intlId: 'jumpDown',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'SaltarArriba',
+    intlId: 'jumpUp',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'SaltarDerecha',
+    intlId: 'jumpRight',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'SaltarIzquierda',
+    intlId: 'jumpLeft',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'HayCharco',
+    intlId: 'puddleHere',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'EscribirLetraActualEnOtraCuadricula',
+    intlId: 'writeLetter',
+    categoryId: 'primitives'
+  },
   {
     id: 'EscribirTextoDadoEnOtraCuadricula',
     intlId: 'writeAnotherText',
@@ -710,16 +553,191 @@ export const sceneBlocks: BlockType[] = [
     id: 'HayVocalRMT',
     intlId: 'isAVowel',
     categoryId: 'sensors'
-  }
+  },
+  {
+    id: 'DibujarLado',
+    intlId: 'drawSide',
+    categoryId: 'primitives',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "DibujarLado",
+      "inputs": {
+        "longitud": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 100
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    id: 'GirarGrados',
+    intlId: 'rotateGrades',
+    categoryId: 'primitives',
+    toolboxJSON: {
+      "kind": "block",
+      "type": "GirarGrados",
+      "inputs": {
+        "grados": {
+          "block": {
+            "type": "math_number",
+            "fields": {
+              "NUM": 90
+            }
+          }
+        }
+      }
+    }
+  },
+   {
+    id: 'SubirPajarito',
+    intlId: 'pickBird',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'Avanzar',
+    intlId: 'advance',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'Retroceder',
+    intlId: 'back',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'RebotarPiePulpito',
+    intlId: 'bounceFootRubberBall',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'RecogerPulpito',
+    intlId: 'pickRubberBall',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'RevolearPulpito',
+    intlId: 'volleyRubberBall',
+    categoryId: 'primitives'
+  },
+   {
+    id: 'VolverABordeIzquierdo',
+    intlId: 'goToLeftBorder',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'PasarASiguienteComputadora',
+    intlId: 'nextComputer',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'ApagarComputadora',
+    intlId: 'turnComputerOff',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'PrenderComputadora',
+    intlId: 'turnComputerOn',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EscribirA',
+    intlId: 'writeA',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EscribirB',
+    intlId: 'writeB',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EscribirC',
+    intlId: 'writeC',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'InstalarJuego',
+    intlId: 'installGame',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'AgarrarTelescopio',
+    intlId: 'takeTelescope',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EntregarPelota',
+    intlId: 'giveBall',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EntregarTelescopio',
+    intlId: 'giveTelescope',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'EntregarCargador',
+    intlId: 'giveCharger',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'IrseEnYacare',
+    intlId: 'goInAlligator',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'Colocar',
+    intlId: 'putIntoTheTrashBin',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'TomarLata',
+    intlId: 'takeCan',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'TomarPapel',
+    intlId: 'takePaper',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'RebotarPingPong',
+    intlId: 'bouncePingPong',
+    categoryId: 'primitives'
+  },
+  {
+    id: 'TocandoDerecha',
+    intlId: 'canMoveRight',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'TocandoAbajo',
+    intlId: 'canMoveDown',
+    categoryId: 'sensors'
+  },
+  {
+    id: 'TocandoGuyra',
+    intlId: 'guyraHere',
+    categoryId: 'sensors'
+  }, 
 ]
 
-const allBlocks: BlockType[] = commonBlocks.concat(sceneBlocks)
+const allBlocks: BlockType[] = commonBlocks.concat(sceneBlocks).concat(challengeOnlyBlocks)
 
 export const getBlockFromId = (id: string): BlockType => allBlocks.find(block => block.id === id)!
 
-export const availableBlocksFor = (sceneType: SceneType): BlockType[] => {
-  return [...sceneBlocks.filter(block => sceneObjectByType(sceneType).specificBlocksIds.includes(block.id)),
-  ...commonBlocks]
+export const availableBlocksFor = (sceneType: SceneType, includeChallengeOnly = false): BlockType[] => {
+
+  const sceneSpecific = sceneBlocks.filter(block =>
+    sceneObjectByType(sceneType).specificBlocksIds.includes(block.id)
+  )
+
+  const extraBlocks = includeChallengeOnly ? challengeOnlyBlocks : []
+
+  return [...sceneSpecific, ...commonBlocks, ...extraBlocks]
+    .filter((block, index, all) => all.findIndex(b => b.id === block.id) === index)
     .sort((a, b) => {
       const position = (block: BlockType) => categories.indexOf(block.categoryId.toLowerCase())
       return position(a) - position(b)

--- a/src/components/blockly/blocks.ts
+++ b/src/components/blockly/blocks.ts
@@ -166,12 +166,7 @@ export const commonBlocks: BlockType[] = [
     id: 'PuedeMoverDerecha',
     intlId: 'canMoveRight',
     categoryId: 'sensors'
-  },
-  {
-    id: 'OpComparacion',
-    intlId: 'logic_compare',
-    categoryId: 'operators'
-  },
+  }
 ]
 
 
@@ -723,7 +718,12 @@ const challengeOnlyBlocks: BlockType[] = [
     id: 'SiguienteTelescopio',
     intlId: 'moveNextTelescope',
     categoryId: 'primitives'
-  }, 
+  },
+  {
+    id: 'OpComparacion',
+    intlId: 'logic_compare',
+    categoryId: 'operators'
+  } 
 ]
 
 const allBlocks: BlockType[] = commonBlocks.concat(sceneBlocks).concat(challengeOnlyBlocks)

--- a/src/components/blockly/blocksGallery/primitives.ts
+++ b/src/components/blockly/blocksGallery/primitives.ts
@@ -633,7 +633,7 @@ export const createPrimitiveBlocks = (t: (key: string) => string) => {
           "name": "grados",
         }
       ],
-      code: 'hacer(actor_id, "Girar", {angulo: - ($grados), voltearAlIrAIzquierda: false, velocidad: 60});',
+      code: 'hacer(actor_id, "Rotar", {angulo: - ($grados), voltearAlIrAIzquierda: false, velocidad: 60});',
       toolbox: `
         <block type="GirarGrados">
           <value name="grados">

--- a/src/components/blockly/blocksGallery/primitives.ts
+++ b/src/components/blockly/blocksGallery/primitives.ts
@@ -620,9 +620,9 @@ export const createPrimitiveBlocks = (t: (key: string) => string) => {
       `
     });
 
-  createPrimitiveBlock('GirarGrados', `${t(`blocks.turnDegrees`)} %1`, { 'comportamiento': '', 'argumentos': '{}' }, 'icono.Girar.png',
+  createPrimitiveBlock('GirarGrados', `${t(`blocks.rotateGrades`)}`, { 'comportamiento': '', 'argumentos': '{}' }, 'icono.Girar.png',
     {
-      message0: `${t(`blocks.turnDegrees`)} %1`,
+      message0: `${t(`blocks.rotateGrades`)}`,
       colour: primitivesColor,
       previousStatement: '',
       nextStatement: '',
@@ -633,7 +633,7 @@ export const createPrimitiveBlocks = (t: (key: string) => string) => {
           "name": "grados",
         }
       ],
-      code: 'hacer(actor_id, "Rotar", {angulo: - ($grados), voltearAlIrAIzquierda: false, velocidad: 60});',
+      code: 'hacer(actor_id, "Girar", {angulo: - ($grados), voltearAlIrAIzquierda: false, velocidad: 60});',
       toolbox: `
         <block type="GirarGrados">
           <value name="grados">

--- a/src/staticData/challenges.ts
+++ b/src/staticData/challenges.ts
@@ -2544,7 +2544,7 @@ const challenges: BasicChallenge[] = [
         [-,L,-,-,-],\
         [A,L,L,L,-],")`,
     toolboxBlockIds: ['Procedimiento', 'MoverACasillaDerecha', 'MoverACasillaArriba',
-      'VolverAlBordeIzquierdo', 'RecogerLata', 'RepetirVacio', 'Repetir', 'Si',
+      'VolverABordeIzquierdo', 'RecogerLata', 'RepetirVacio', 'Repetir', 'Si',
       'SiNo', 'Hasta', 'Numero'],
     expectations: {
       decomposition: false,

--- a/src/staticData/challenges.ts
+++ b/src/staticData/challenges.ts
@@ -1480,7 +1480,7 @@ const challenges: BasicChallenge[] = [
       'Repetir',
       'Si',
       'SiNo',
-      'hayVocalRMT'
+      'HayVocalRMT'
     ],
   },
 
@@ -1498,7 +1498,7 @@ const challenges: BasicChallenge[] = [
       'Repetir',
       'Si',
       'SiNo',
-      'hayVocalRMT'
+      'HayVocalRMT'
     ],
   },
 
@@ -2472,7 +2472,7 @@ const challenges: BasicChallenge[] = [
         [*,*,*,*,*],\
       ", { coleccion: ["G", "A"] })`,
     toolboxBlockIds: ['Repetir', 'Si', 'SiNo', 'Hasta', 'Procedimiento',
-      'VolverAlBordeIzquierdo', 'MoverACasillaDerecha', 'TocandoGuyra','SubirPajarito'],
+      'VolverABordeIzquierdo', 'MoverACasillaDerecha', 'TocandoGuyra','SubirPajarito'],
     expectations: {
       conditionalRepetition: true,
     }


### PR DESCRIPTION
Resolves #361 

> Los bloques que usamos en los desafíos están en `sceneBlocks` y en `commonBlocks`. También existen los `notusedBlocks` que se crearon para que esos bloques NO aparezcan en el selector del creador.
> El problema ahora es que algunos de esos bloques son necesarios para los desafíos de coty (207 por ejemplo) o toto (251 por ejemplo).

Creé una nueva lista llamada `challengeOnlyBlocks` la cual va a contener los bloques que deben existir en desafíos pero no en el selector del creador.

Eliminé a la lista 'notusedBlocks'  ya que quedó vaciá y estamos utilizando todos los bloques.

Modifiqué la función `availableBlocksFor()` para aceptar el parámetro opcional `includeChallengeOnly `(un booleano que por defecto es `false`). Esto permite ocultar ciertos bloques en la interfaz del creador de escenarios que solo deben estar disponibles en los desafíos.  

Hice una corrección de Ejercicios y Bloques en donde no bastaba solo mover los bloques ya sea por error de tipeo o porque faltaba un bloque:

- Ejercicio 244 (Coty): Se creó el bloque `HayCharco` necesario para el charco.  Tomando como referencia el bloque en Ember
- Ejercicios 253 y 254 (Toto): Se corrigió una inconsistencia de mayúsculas en challenges.ts, cambiando `HayVocalRMT` por la forma correcta: `hayVocalRMT`.  
- Ejercicio 255 (Coty): Se resolvió un error de carga por el cual Blockly arrojaba que faltaba el input `longitud` en el bloque `GirarGrados`. Se unificó el criterio modificando `blocks.ts` para que use `grados` , alineándose con la definición original en `primitives.ts`.  
- Ejercicios 1022 (Capy) y 1028 (Capy y Guyrá): Se corrigió un error de tipeo en `challenges.ts` donde decía `VolverAlBordeIzquierdo` en lugar de `VolverABordeIzquierdo`.   
- Ejercicio 1135 (CHUY): Se creó el bloque `OpComparacion` (de la categoría `operators`) y se añadió a la lista de bloques `challengeOnlyBlocks`. Se tomó como referencia el mismo bloque pero en ember. 