### PR TITLE
incluir credenciales en fetch para guardar cookie de sesión del foro

### DIFF
--- a/src/pbApi.ts
+++ b/src/pbApi.ts
@@ -164,7 +164,8 @@ export namespace PilasBloquesApi{
         return _doFetch(url, {
           method,
           body: JSON.stringify(await bodyWithContext<T>(body)),
-          headers
+          headers,
+          credentials: 'include'
         })  
           .catch(connectionErr => {
             if (critical) throw connectionErr


### PR DESCRIPTION
Resolves #367 
Related https://github.com/Program-AR/pilas-bloques-backend/pull/29

Se modificó el módulo de comunicación con la API (src/pbApi.ts) para incluir `credentials: 'include'` en las opciones de fetch. Esto permite que el navegador acepte y guarde correctamente las cookies enviadas por el backend en escenarios cross-origin.