### PR TITLE
se agrego el boton de sugerencias y se guarda su estado en el local storage

### DIFF
--- a/locales/en-us/challenge.json
+++ b/locales/en-us/challenge.json
@@ -40,6 +40,8 @@
   "multipleScenarios": "There are multiple scenarios!",
   "close": "Close",
   "solutionButtons": {
+    "disableSuggestions": "Disable suggestions",
+    "enableSuggestions": "Enable suggestions",
     "download": "Download solution",
     "upload": "Upload solution",
     "clear": "Clear the current solution",

--- a/locales/es-ar/challenge.json
+++ b/locales/es-ar/challenge.json
@@ -40,6 +40,8 @@
   "multipleScenarios": "¡Hay varios escenarios!",
   "close": "Cerrar",
   "solutionButtons": {
+    "disableSuggestions": "Desactivar sugerencias",
+    "enableSuggestions": "Activar sugerencias",
     "download": "Descargar solución",
     "upload": "Cargar solución",
     "clear": "Borrar la solución actual",

--- a/locales/pt-br/challenge.json
+++ b/locales/pt-br/challenge.json
@@ -40,6 +40,8 @@
   "multipleScenarios": "Existem vários cenários!",
   "close": "Fechar",
   "solutionButtons": {
+    "disableSuggestions": "Desativar sugestões",
+    "enableSuggestions": "Ativar sugestões",
     "download": "Baixe a solução",
     "upload": "Carregar solução",
     "clear": "Exclua a solução atual",

--- a/src/components/blockly/blocklyValidations.ts
+++ b/src/components/blockly/blocklyValidations.ts
@@ -3,6 +3,7 @@ import { analyzeWithMulang } from './mulang/pilasMulangAnalyzer'
 import { showMulangFeedback } from './mulang/blockFeedback'
 import { TFunction } from 'i18next'
 import { MulangExpectationResult } from './mulang/mulangResults'
+import { LocalStorage } from '../../localStorage'
 
 const REQUIRED_PLACEHOLDERS = ['required_value', 'required_statement']
 
@@ -80,7 +81,10 @@ export const runBlocklyValidations = async (
     challenge
   )
 
-  showMulangFeedback(workspace, mulangResults, t)
+  const showSuggestions = LocalStorage.getMulangSuggestionsEnabled()
+  const resultsToShow = showSuggestions ? mulangResults : mulangResults.filter(r => r.isCritical)
+
+  showMulangFeedback(workspace, resultsToShow, t)
 
   const hasCriticalErrors = mulangResults.some(
     result => result.result === false && result.isCritical

--- a/src/components/blockly/blocklyValidations.ts
+++ b/src/components/blockly/blocklyValidations.ts
@@ -59,10 +59,22 @@ const blockHasMissingInput = (block: any) => {
   })
 }
 
+let lastChallenge: any = null
+let lastT: TFunction | null = null
+
+export const refreshBlocklyValidations = async () => {
+  if (lastChallenge && lastT) {
+    await runBlocklyValidations(lastChallenge, lastT)
+  }
+}
+
 export const runBlocklyValidations = async (
   challenge: any,
   t: TFunction
 ): Promise<BlocklyValidationResult> => {
+  lastChallenge = challenge
+  lastT = t
+  
   const workspace = Blockly.getMainWorkspace()
   const blocks = workspace
     .getAllBlocks(false)

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -2,13 +2,16 @@ import { Button, Dialog, DialogContent, DialogTitle, IconButton, IconButtonProps
 import DownloadIcon from '@mui/icons-material/Download';
 import ClearIcon from '@mui/icons-material/Clear';
 import CleaningServicesIcon from '@mui/icons-material/CleaningServices';
+import CommentsDisabledIcon from '@mui/icons-material/CommentsDisabled';
+import CommentIcon from '@mui/icons-material/Comment';
+import { PBSwitch, pbIconStyle } from "../PBSwitch";
 import { useThemeContext } from "../../theme/ThemeContext";
 import { useTranslation } from "react-i18next";
 import Blockly from "blockly/core"
 import { LocalStorage } from "../../localStorage";
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import { setXml, workspaceToXmlText, xmlBloqueEmpezarAEjecutar } from "../blockly/blockly";
-import { ChangeEvent, useRef, useState } from "react";
+import { ChangeEvent, useRef, useState, useEffect } from "react";
 
 
 type SolucionButtonsProps = {
@@ -20,6 +23,7 @@ export const SolutionButtons = (props: SolucionButtonsProps) => {
 
   return (
     <Stack direction={props.direction} spacing={2}>
+      <ToggleSuggestionsButton />
       <UploadSolution />
       <SaveSolutionButton />
       <ClearSolutionButton />
@@ -27,6 +31,39 @@ export const SolutionButtons = (props: SolucionButtonsProps) => {
 
   );
 
+}
+
+const ToggleSuggestionsButton = () => {
+  const { theme } = useThemeContext()
+  const { t } = useTranslation('challenge')
+  const [enabled, setEnabled] = useState(() => LocalStorage.getMulangSuggestionsEnabled())
+
+  const handleToggle = () => {
+    const newState = !enabled
+    setEnabled(newState)
+    LocalStorage.saveMulangSuggestionsEnabled(newState)
+  }
+
+  return (
+    <Tooltip title={enabled ? t("solutionButtons.disableSuggestions") : t("solutionButtons.enableSuggestions")}>
+      <PBSwitch
+        checked={enabled}
+        sx={{
+          "& .MuiSwitch-switchBase": {
+            "&.Mui-checked": {
+              "+ .MuiSwitch-track": {
+                backgroundColor: theme.palette.secondary.main,
+                opacity: 1,
+              }
+            },
+          },
+        }}
+        icon={<CommentsDisabledIcon sx={pbIconStyle(theme)} />}
+        checkedIcon={<CommentIcon sx={pbIconStyle(theme)} />}
+        onChange={handleToggle}
+      />
+    </Tooltip>
+  )
 }
 
 type SolucionButtonProps = {

--- a/src/components/challengeView/SolutionButtons.tsx
+++ b/src/components/challengeView/SolutionButtons.tsx
@@ -12,6 +12,7 @@ import { LocalStorage } from "../../localStorage";
 import DriveFolderUploadIcon from '@mui/icons-material/DriveFolderUpload';
 import { setXml, workspaceToXmlText, xmlBloqueEmpezarAEjecutar } from "../blockly/blockly";
 import { ChangeEvent, useRef, useState, useEffect } from "react";
+import { refreshBlocklyValidations } from "../blockly/blocklyValidations";
 
 
 type SolucionButtonsProps = {
@@ -22,7 +23,7 @@ type SolucionButtonsProps = {
 export const SolutionButtons = (props: SolucionButtonsProps) => {
 
   return (
-    <Stack direction={props.direction} spacing={2}>
+    <Stack direction={props.direction} spacing={2} alignItems="center">
       <ToggleSuggestionsButton />
       <UploadSolution />
       <SaveSolutionButton />
@@ -42,6 +43,7 @@ const ToggleSuggestionsButton = () => {
     const newState = !enabled
     setEnabled(newState)
     LocalStorage.saveMulangSuggestionsEnabled(newState)
+    refreshBlocklyValidations()
   }
 
   return (

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -12,6 +12,7 @@ export namespace LocalStorage {
     const PB_USE_NIGHT_THEME = 'PB_USE_NIGHT_THEME'
     const PB_USE_SIMPLE_READ = 'PB_USE_SIMPLE_READ'
     const PB_USER_IP = 'PB_USER_IP'
+    const PB_MULANG_SUGGESTIONS_ENABLED = 'PB_MULANG_SUGGESTIONS_ENABLED'
 
     const remove = (key: string) => { localStorage.removeItem(key) }
 
@@ -22,6 +23,10 @@ export namespace LocalStorage {
     export const getIsDarkMode = (): boolean => _get(PB_USE_NIGHT_THEME) || false
     export const getIsSimpleReadMode = (): boolean => _get(PB_USE_SIMPLE_READ) || false
     export const getUserIp = (): string | null => _get(PB_USER_IP)
+    export const getMulangSuggestionsEnabled = (): boolean => {
+        const val = _get(PB_MULANG_SUGGESTIONS_ENABLED);
+        return val === null ? true : val;
+    }
 
     export const saveSelectedLocale = (selectedLocale: LanguageCode) => _save(PB_SELECTED_LOCALE, selectedLocale)
     export const saveImportedChallenge = (importedChallenge: EmberExecutableChallenge) => _save(PB_IMPORTED_CHALLENGE, importedChallenge)
@@ -30,6 +35,7 @@ export namespace LocalStorage {
     export const saveDarkMode = (darkMode: boolean) => _save(PB_USE_NIGHT_THEME, darkMode)
     export const saveSimpleReadMode = (simpleReadMode: boolean) => _save(PB_USE_SIMPLE_READ, simpleReadMode)
     export const saveUserIp = (userIp: string) => _save(PB_USER_IP, userIp)
+    export const saveMulangSuggestionsEnabled = (enabled: boolean) => _save(PB_MULANG_SUGGESTIONS_ENABLED, enabled)
 
     const _get = (key: string) => _doSafe(key, (storage: Storage) => {
         const value = storage.getItem(key)

--- a/src/test/unit/components/SolutionButtons.test.tsx
+++ b/src/test/unit/components/SolutionButtons.test.tsx
@@ -12,27 +12,34 @@ jest.mock('../../../localStorage', () => ({
   }
 }))
 
+jest.mock('../../../components/blockly/blocklyValidations')
+
 describe('SolutionButtons', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+      // resetMocks:true (jest config) wipes jest.fn() implementations before each test,
+      // so we restore the ones this test depends on.
+      ; (LocalStorage.getMulangSuggestionsEnabled as jest.Mock).mockReturnValue(true)
+      ; (LocalStorage.getCreatorChallenge as jest.Mock).mockReturnValue({ title: 'test' })
+      ; (LocalStorage.getSelectedLocale as jest.Mock).mockReturnValue('es-ar')
   })
 
   test('renders toggle suggestions button and toggles state', async () => {
     renderComponent(<SolutionButtons direction="row" />)
-    
+
     // The switch uses a checkbox input under the hood
     const toggleInput = await screen.findByRole('checkbox')
     expect(toggleInput).toBeInTheDocument()
-    
+
     // Should be initially checked because getMulangSuggestionsEnabled returns true
     expect(toggleInput).toBeChecked()
 
     // Click to toggle
     fireEvent.click(toggleInput)
-    
+
     // Should now be unchecked
     expect(toggleInput).not.toBeChecked()
-    
+
     // Should have saved the new state to localStorage
     expect(LocalStorage.saveMulangSuggestionsEnabled).toHaveBeenCalledWith(false)
   })

--- a/src/test/unit/components/SolutionButtons.test.tsx
+++ b/src/test/unit/components/SolutionButtons.test.tsx
@@ -1,0 +1,39 @@
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { SolutionButtons } from '../../../components/challengeView/SolutionButtons'
+import { renderComponent } from '../../testUtils'
+import { LocalStorage } from '../../../localStorage'
+
+jest.mock('../../../localStorage', () => ({
+  LocalStorage: {
+    getMulangSuggestionsEnabled: jest.fn(() => true),
+    saveMulangSuggestionsEnabled: jest.fn(),
+    getCreatorChallenge: jest.fn(() => ({ title: 'test' })),
+    getSelectedLocale: jest.fn(() => 'es-ar'),
+  }
+}))
+
+describe('SolutionButtons', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders toggle suggestions button and toggles state', async () => {
+    renderComponent(<SolutionButtons direction="row" />)
+    
+    // The switch uses a checkbox input under the hood
+    const toggleInput = await screen.findByRole('checkbox')
+    expect(toggleInput).toBeInTheDocument()
+    
+    // Should be initially checked because getMulangSuggestionsEnabled returns true
+    expect(toggleInput).toBeChecked()
+
+    // Click to toggle
+    fireEvent.click(toggleInput)
+    
+    // Should now be unchecked
+    expect(toggleInput).not.toBeChecked()
+    
+    // Should have saved the new state to localStorage
+    expect(LocalStorage.saveMulangSuggestionsEnabled).toHaveBeenCalledWith(false)
+  })
+})


### PR DESCRIPTION
Resolves #243 

Se agregó el botón de sugerencias y su estado se mantiene en el local storage de forma tal que el usuario pueda cambiar de desafio y mantener esa configuración.

Sugerencias activadas y solución larga:
<img width="1911" height="720" alt="Captura de pantalla 2026-07-14 111019" src="https://github.com/user-attachments/assets/8766ec59-d1e3-4d51-b8dd-1d4a66c03800" />

Sugerencias desactivadas y solución larga:
<img width="1917" height="748" alt="Captura de pantalla 2026-07-14 111045" src="https://github.com/user-attachments/assets/deb736ec-26a1-463b-a930-47dac5acdda0" />

Sugerencias activadas y solución dividida correctamente en sub tareas
<img width="1917" height="711" alt="Captura de pantalla 2026-07-14 111509" src="https://github.com/user-attachments/assets/dcc97faf-53bf-412d-9b26-7f66a905d482" />

Botón en la versión mobile:
<img width="1080" height="2340" alt="Screenshot_20260714_110939_Chrome" src="https://github.com/user-attachments/assets/b4dd98f7-b7cc-4a7e-b68a-ef31f8009851" />
