### PR TITLE
Control group no more

### DIFF
--- a/locales/en-us/mulang.json
+++ b/locales/en-us/mulang.json
@@ -14,25 +14,22 @@
     "check_out_this_block": "Check out this block."
   },
   "scoreable": {
-    "solution_works": "Your solution works!",
-    "uses_simple_repetition": "{result, select, \n  true {You're using}\n  other {You should Use}\n} repetition for the repeating parts of the program.\n",
-    "uses_conditional_alternative": "{result, select, \n  true {You're using}\n  other {You should Use}\n} conditional alternatives to consider all possible scenarios.\n",
-    "uses_conditional_repetition": "{result, select, \n  true {You're using}\n  other {You should Use}\n} conditional repetition to consider varying scenarios.\n",
-    "main_too_long": "{result, select, \n  true {The main program is short and legible.}\n  other {Main program is too long, it should be divided into simpler pieces of work}\n}\n",
-    "too_long": "{result, select, \n  true {Your procedures are}\n  other {Your procedures should be}\n} divided into simpler pieces of work.\n",
-    "do_something": "{result, select, \n  true {Your procedures are not empty, they contain blocks}\n  other {Your procedures are empty, they should contain blocks}\n}.\n",
-    "name_was_changed": "{result, select,\n  true {You chose}\n  other {You should choose}\n} a name for each one of your procedures.\n",
-    "does_not_nest_control_structures": "{result, select, \n  true {Your repetitions and alternatives are subdivided}\n  other {You should also subdivide your repetitions and alternatives}\n} into simpler pieces of work using procedures.\n"
-  },
-  "control_group": {
     "solution_works": "Your solution _works_!",
-    "uses_simple_repetition": "You should use simple repetition for the repeating parts of your program.",
-    "uses_conditional_alternative": "You should use conditional alternative to consider all possible scenarios.",
-    "uses_conditional_repetition": "You should use conditional repetition to consider all scenarios.",
-    "main_too_long": "The main program should be subdivided into simpler pieces of work using procedures.",
-    "too_long": "Your procedures should not be long, they should also be subdivided into simpler pieces of work (procedures).",
-    "do_something": "You should not have empty procedures with no blocks.",
-    "name_was_changed": "You should choose a good name for each one of your procedures.",
-    "does_not_nest_control_structures": "You should also divide your repetitions and alternatives into simpler pieces of work using procedures."
+    "uses_simple_repetition_passed": "You're using repetition for the repeating parts of the program.",
+    "uses_simple_repetition_failed": "You should use repetition for the repeating parts of the program.",
+    "uses_conditional_alternative_passed": "You're using conditional alternatives to consider all possible scenarios.",
+    "uses_conditional_alternative_failed": "You should use conditional alternatives to consider all possible scenarios.",
+    "uses_conditional_repetition_passed": "You're using conditional repetition to consider varying scenarios.",
+    "uses_conditional_repetition_failed": "You should use conditional repetition to consider varying scenarios.",
+    "main_too_long_passed": "The main program is short and legible.",
+    "main_too_long_failed": "Main program is too long, it should be divided into simpler pieces of work.",
+    "too_long_passed": "Your procedures are divided into simpler pieces of work.",
+    "too_long_failed": "Your procedures should be divided into simpler pieces of work.",
+    "do_something_passed": "Your procedures are not empty, they contain blocks.",
+    "do_something_failed": "Your procedures are empty, they should contain blocks.",
+    "name_was_changed_passed": "You chose a name for each one of your procedures.",
+    "name_was_changed_failed": "You should choose a name for each one of your procedures.",
+    "does_not_nest_control_structures_passed": "Your repetitions and alternatives are subdivided into simpler pieces of work using procedures.",
+    "does_not_nest_control_structures_failed": "You should also subdivide your repetitions and alternatives into simpler pieces of work using procedures."
   }
 }

--- a/locales/es-ar/mulang.json
+++ b/locales/es-ar/mulang.json
@@ -14,25 +14,22 @@
     "check_out_this_block": "Revisá este bloque."
   },
   "scoreable": {
-    "solution_works": "¡Tu solución _funciona_!",
-    "uses_simple_repetition": "{result, select, \n  true {Usás}\n  other {Deberías usar}\n} **repetición simple** para las partes de tu programa que hay que repetir.\n",
-    "uses_conditional_alternative": "{result, select, \n  true {Usás}\n  other {Deberías usar}\n} **alternativa condicional** para considerar los escenarios variantes.\n",
-    "uses_conditional_repetition": "{result, select, \n  true {Usás}\n  other {Deberías usar}\n} **repetición condicional** :repeat: para considerar los escenarios variantes.\n",
-    "main_too_long": "{result, select, \n  true {El _programa principal_ es corto, y por eso es más **fácil de leer**.}\n  other {El _programa principal_ es largo, y por eso es **difícil de leer**. <br/> :point_right: Debería estar dividido en subtareas usando **procedimientos**.}\n}\n",
-    "too_long": "{result, select, \n  true {Tus _procedimientos_ son cortos y por eso son más **fáciles de leer**.}\n  other {Tus _procedimientos_ son largos y por eso son más **difíciles de leer**. <br/> :point_right: Deberían estar divididos en subtareas usando **más procedimientos** dentro de ellos.}\n}\n",
-    "do_something": "{result, select, \n  true {Tus _procedimientos_ no están vacíos, **tienen bloques** adentro}\n  other {Tus _procedimientos_ están **vacíos** <br/> :point_right: deberían tener bloques en su interior}\n}.\n",
-    "name_was_changed": "{result, select,\n  true {Elegiste}\n  other {Tus procedimientos se llaman \"Hacer algo\" <br/> :point_right: Podrías elegir}\n} un **nombre** para cada uno de tus procedimientos.\n",
-    "does_not_nest_control_structures": "{result, select, \n  true {Tu programa es más fácil de leer porque tus _repeticiones y alternativas_ están divididas}\n  other {Para que tu programa sea más fácil de leer <br/> :point_right: dentro de las _repeticiones y alternativas_ deberías dividir}\n} en subtareas usando **procedimientos**.\n"
-  },
-  "control_group": {
-    "solution_works": "¡Tu solución _funciona_!",
-    "uses_simple_repetition": "Deberías usar **repetición simple** :repeat: para las partes de tu programa que se repiten.",
-    "uses_conditional_alternative": "Deberías usar **alternativa condicional** para considerar todos los escenarios.",
-    "uses_conditional_repetition": "Deberías usar **repetición condicional** para considerar todos los escenarios.",
-    "main_too_long": "El _programa principal_ debería ser corto y **fácil de leer**. Podés hacerlo más corto dividiéndolo en subtareas usando **procedimientos**.",
-    "too_long": "Tus _procedimientos_ deberían ser cortos y **fáciles de leer**. Podés hacerlos más cortos dividiéndolos en subtareas usando **más procedimientos** dentro de ellos.",
-    "do_something": "No deberías tener procedimientos **vacíos**, sin bloques.",
-    "name_was_changed": "Deberías elegir un buen **nombre** para cada uno de tus procedimientos.",
-    "does_not_nest_control_structures": "Dentro de las repeticiones y alternativas también deberías dividir en subtareas usando **procedimientos**."
+    "solution_works": "¡Tu solución funciona!",
+    "uses_simple_repetition_passed": "Usás **repetición simple** para las partes de tu programa que hay que repetir.",
+    "uses_simple_repetition_failed": "Deberías usar **repetición simple** para las partes de tu programa que hay que repetir.",
+    "uses_conditional_alternative_passed": "Usás **alternativa condicional** para considerar los escenarios variantes.",
+    "uses_conditional_alternative_failed": "Deberías usar **alternativa condicional** para considerar los escenarios variantes.",
+    "uses_conditional_repetition_passed": "Usás **repetición condicional** 🔁 para considerar los escenarios variantes.",
+    "uses_conditional_repetition_failed": "Deberías usar **repetición condicional** 🔁 para considerar los escenarios variantes.",
+    "main_too_long_passed": "El _programa principal_ es corto, y por eso es más **fácil de leer**.",
+    "main_too_long_failed": "El _programa principal_ es largo, y por eso es **difícil de leer**.<br/> 👉 Debería estar dividido en subtareas usando **procedimientos**.",
+    "too_long_passed": "Tus _procedimientos_ son cortos y por eso son más **fáciles de leer**.",
+    "too_long_failed": "Tus _procedimientos_ son largos y por eso son más **difíciles de leer**.<br/> 👉 Deberían estar divididos en subtareas usando **más procedimientos** dentro de ellos.",
+    "do_something_passed": "Tus _procedimientos_ no están vacíos, **tienen bloques** adentro.",
+    "do_something_failed": "Tus _procedimientos_ están **vacíos**.<br/> 👉 Deberían tener bloques en su interior.",
+    "name_was_changed_passed": "Elegiste un **nombre** para cada uno de tus procedimientos.",
+    "name_was_changed_failed": "Tus procedimientos se llaman \"Hacer algo\".<br/> 👉 Podrías elegir un **nombre** para cada uno de tus procedimientos.",
+    "does_not_nest_control_structures_passed": "Tu programa es más fácil de leer porque tus _repeticiones y alternativas_ están divididas en subtareas usando **procedimientos**.",
+    "does_not_nest_control_structures_failed": "Para que tu programa sea más fácil de leer,<br/> 👉 dentro de las _repeticiones y alternativas_ deberías dividir en subtareas usando **procedimientos**."
   }
 }

--- a/locales/pt-br/mulang.json
+++ b/locales/pt-br/mulang.json
@@ -14,25 +14,22 @@
     "check_out_this_block": "Revise este bloco."
   },
   "scoreable": {
-    "solution_works": "Sua solução funciona!",
-    "uses_simple_repetition": "{result, select, \n  true {Você usa}\n  other {Você deveria usar}\n} repetição para as partes do seu programa que se repetem.\n",
-    "uses_conditional_alternative": "{result, select, \n  true {Você usa}\n  other {Você deveria usar}\n} alternativa condicional para considerar os cenários variáveis.\n",
-    "uses_conditional_repetition": "{result, select, \n  true {Você usa}\n  other {Você deveria usar}\n} repetição condicional para considerar os cenários variáveis.\n",
-    "main_too_long": "{result, select, \n  true {O programa principal é curto e legível.}\n  other {O programa principal é longo, deveria estar dividido em subtarefas.}\n} \n",
-    "too_long": "{result, select, \n  true {Seus procedimentos estão}\n  other {Seus procedimentos deveriam estar}\n} divididos em subtarefas.\n",
-    "do_something": "{result, select, \n  true {Seus procedimentos não estão vazios, têm blocos dentro}\n  other {Seus procedimentos estão vazios, deveriam ter blocos dentro}\n}.\n",
-    "name_was_changed": "{result, select,\n  true {Você escolheu}\n  other {Você poderia escolher}\n} um nome para cada um dos seus procedimentos.\n",
-    "does_not_nest_control_structures": "{result, select, \n  true {Suas repetições e alternativas estão divididas}\n  other {Dentro das repetições e alternativas, você também deveria dividir}\n} em subtarefas usando procedimentos.\n"
-  },
-  "control_group": {
     "solution_works": "Sua solução _funciona_!",
-    "uses_simple_repetition": "Você deveria usar repetição simples para as partes do seu programa que se repetem.",
-    "uses_conditional_alternative": "Você deveria usar alternativa condicional para considerar todos os cenários.",
-    "uses_conditional_repetition": "Você deveria usar repetição condicional para considerar todos os cenários.",
-    "main_too_long": "O programa principal deveria estar dividido em subtarefas usando procedimentos.",
-    "too_long": "Seus procedimentos não deveriam ser longos, também deveriam estar divididos em subtarefas.",
-    "do_something": "Você não deveria ter procedimentos vazios, sem blocos.",
-    "name_was_changed": "Você deveria escolher um bom nome para cada um dos seus procedimentos.",
-    "does_not_nest_control_structures": "Dentro das repetições e alternativas, você também deveria dividir em subtarefas usando procedimentos."
+    "uses_simple_repetition_passed": "Você usa repetição para as partes do seu programa que se repetem.",
+    "uses_simple_repetition_failed": "Você deveria usar repetição para as partes do seu programa que se repetem.",
+    "uses_conditional_alternative_passed": "Você usa alternativa condicional para considerar os cenários variáveis.",
+    "uses_conditional_alternative_failed": "Você deveria usar alternativa condicional para considerar os cenários variáveis.",
+    "uses_conditional_repetition_passed": "Você usa repetição condicional para considerar os cenários variáveis.",
+    "uses_conditional_repetition_failed": "Você deveria usar repetição condicional para considerar os cenários variáveis.",
+    "main_too_long_passed": "O programa principal é curto e legível.",
+    "main_too_long_failed": "O programa principal é longo, deveria estar dividido em subtarefas.",
+    "too_long_passed": "Seus procedimentos estão divididos em subtarefas.",
+    "too_long_failed": "Seus procedimentos deveriam estar divididos em subtarefas.",
+    "do_something_passed": "Seus procedimentos não estão vazios, têm blocos dentro.",
+    "do_something_failed": "Seus procedimentos estão vazios, deveriam ter blocos dentro.",
+    "name_was_changed_passed": "Você escolheu um nome para cada um dos seus procedimentos.",
+    "name_was_changed_failed": "Você poderia escolher um nome para cada um dos seus procedimentos.",
+    "does_not_nest_control_structures_passed": "Suas repetições e alternativas estão divididas em subtarefas usando procedimentos.",
+    "does_not_nest_control_structures_failed": "Dentro das repetições e alternativas, você também deveria dividir em subtarefas usando procedimentos."
   }
 }

--- a/src/components/blockly/blocklyValidations.ts
+++ b/src/components/blockly/blocklyValidations.ts
@@ -96,7 +96,15 @@ export const runBlocklyValidations = async (
   const showSuggestions = LocalStorage.getMulangSuggestionsEnabled()
   const resultsToShow = showSuggestions ? mulangResults : mulangResults.filter(r => r.isCritical)
 
-  showMulangFeedback(workspace, resultsToShow, t)
+  const isSimpleReadMode = LocalStorage.getIsSimpleReadMode()
+  const customT = (key: string, options?: any) => {
+    const translation = t(key, options)
+    return isSimpleReadMode && typeof translation === 'string'
+      ? translation.toUpperCase()
+      : translation
+  }
+
+  showMulangFeedback(workspace, resultsToShow, customT as TFunction)
 
   const hasCriticalErrors = mulangResults.some(
     result => result.result === false && result.isCritical

--- a/src/components/blockly/mulang/blockFeedback.ts
+++ b/src/components/blockly/mulang/blockFeedback.ts
@@ -1,6 +1,8 @@
 import * as Blockly from 'blockly/core'
 import { MulangExpectationResult } from './mulangResults'
 import { messageForExpectation } from './expectationMessages'
+import { doesNotNestControlStructuresId } from './expectations'
+import { getNestedControlStructureBlocks } from './blockUtils'
 import { TFunction } from 'i18next'
 
 const entryPointType = 'al_empezar_a_ejecutar'
@@ -45,19 +47,23 @@ const findProcedureBlock = (
   )
 }
 
-const blockForResult = (
+const blocksForResult = (
   workspace: Blockly.Workspace,
   result: MulangExpectationResult
-) => {
-  if (result.declaration === entryPointType) {
-    return findEntryPointBlock(workspace)
+): any[] => {
+  const declarationBlock = result.declaration === entryPointType
+    ? findEntryPointBlock(workspace)
+    : result.declaration
+      ? findProcedureBlock(workspace, result.declaration)
+      : findEntryPointBlock(workspace)
+
+  if (!declarationBlock) return []
+
+  if (result.id === doesNotNestControlStructuresId) {
+    return getNestedControlStructureBlocks(declarationBlock)
   }
 
-  if (result.declaration) {
-    return findProcedureBlock(workspace, result.declaration)
-  }
-
-  return findEntryPointBlock(workspace)
+  return [declarationBlock]
 }
 
 export const showMulangFeedback = (
@@ -68,13 +74,15 @@ export const showMulangFeedback = (
   const messagesByBlock = new Map<any, string[]>()
 
   failedResults(results).forEach(result => {
-    const block = blockForResult(workspace, result)
-    if (!block) return
+    const blocks = blocksForResult(workspace, result)
+    if (!blocks || !blocks.length) return
 
     const message = messageForExpectation(result, t)
 
-    const currentMessages = messagesByBlock.get(block) || []
-    messagesByBlock.set(block, [...currentMessages, message])
+    blocks.forEach(block => {
+      const currentMessages = messagesByBlock.get(block) || []
+      messagesByBlock.set(block, [...currentMessages, message])
+    })
   })
 
   messagesByBlock.forEach((messages, block) => {

--- a/src/components/blockly/mulang/blockUtils.ts
+++ b/src/components/blockly/mulang/blockUtils.ts
@@ -9,17 +9,58 @@ export const allProcedureNames = (workspace: Blockly.Workspace) =>
     .map((block: any) => block.getFieldValue?.('NAME'))
     .filter(Boolean)
 
-export const allBlocksNestingControlStructures = (workspace: Blockly.Workspace) =>
-  workspace
-    .getAllBlocks(false)
-    .filter((block: any) =>
-      ['Si', 'SiNo', 'si', 'Sino', 'sino', 'Repetir', 'repetir', 'Hasta', 'hasta'].includes(block.type)
-    )
-    .filter((block: any) =>
-      block
-        .getChildren(false)
-        .some((child: any) =>
-          ['Si', 'SiNo', 'si', 'Sino', 'sino', 'Repetir', 'repetir', 'Hasta', 'hasta'].includes(child.type)
-        )
-    )
-    .map((block: any) => block.type)
+const CONTROL_STRUCTURE_TYPES = [
+  'Si', 'SiNo', 'si', 'Sino', 'sino',
+  'Repetir', 'repetir', 'Hasta', 'hasta',
+  'RepetirVacio'
+]
+
+export const isControlStructure = (block: any) =>
+  Boolean(block && CONTROL_STRUCTURE_TYPES.includes(block.type))
+
+export const nestsControlStructures = (containerBlock: any) => {
+  if (!containerBlock) return false
+  const descendants = containerBlock.getDescendants?.(false) || []
+  const controlBlocks = descendants.filter(isControlStructure)
+
+  return controlBlocks.some((block: any) => {
+    const parent = block.getSurroundParent?.()
+    if (isControlStructure(parent)) return true
+
+    const subDescendants = block.getDescendants?.(false) || []
+    return subDescendants.slice(1).some(isControlStructure)
+  })
+}
+
+export const allBlocksNestingControlStructures = (workspace: Blockly.Workspace) => {
+  const allBlocks = workspace.getAllBlocks(false)
+  const entryPointBlock = allBlocks.find((b: any) => b.type === entryPointType)
+  const procedureBlocks = allBlocks.filter((b: any) => b.type === 'procedures_defnoreturn')
+
+  const declarationNames: string[] = []
+
+  if (entryPointBlock && nestsControlStructures(entryPointBlock)) {
+    declarationNames.push(entryPointType)
+  }
+
+  procedureBlocks.forEach((procBlock: any) => {
+    if (nestsControlStructures(procBlock)) {
+      const name = procBlock.getFieldValue?.('NAME')
+      if (name) {
+        declarationNames.push(name)
+      }
+    }
+  })
+
+  return declarationNames
+}
+
+export const getNestedControlStructureBlocks = (declarationBlock: any) => {
+  if (!declarationBlock) return []
+  const descendants = declarationBlock.getDescendants?.(false) || []
+  return descendants.filter((block: any) => {
+    if (!isControlStructure(block)) return false
+    const parent = block.getSurroundParent?.()
+    return isControlStructure(parent)
+  })
+}

--- a/src/components/blockly/mulang/challengeExpectations.ts
+++ b/src/components/blockly/mulang/challengeExpectations.ts
@@ -51,7 +51,7 @@ const idsToExpectations = (defaultProcedureName: string) => ({
   ),
 })
 
-const mergeConfigurations = (expectationsConfigs: Array<Record<string, boolean> | undefined>) =>
+export const mergeConfigurations = (expectationsConfigs: Array<Record<string, boolean> | undefined>) =>
   expectationsConfigs
     .filter(Boolean)
     .reduce((baseExpect, expectWithPriority) => ({
@@ -59,7 +59,7 @@ const mergeConfigurations = (expectationsConfigs: Array<Record<string, boolean> 
       ...expectWithPriority,
     }), {} as Record<string, boolean>)
 
-const configToExpectation = (
+export const configToExpectation = (
   expectationsConfig: Record<string, boolean> | undefined,
   workspace: Blockly.WorkspaceSvg,
   defaultProcedureName: string

--- a/src/components/blockly/mulang/expectations.ts
+++ b/src/components/blockly/mulang/expectations.ts
@@ -144,9 +144,10 @@ export const noExpectation = () => ''
 export const parseExpect = (name: string) => {
   const expectationName = name.split('|')[0]
 
-  const stringToBool = (value: string) => {
-    if (value === 'true') return true
-    if (value === 'false') return false
+  const parseParamValue = (value: string) => {
+    const trimmed = value.trim()
+    if (trimmed === 'true') return true
+    if (trimmed === 'false') return false
     return value
   }
 
@@ -157,7 +158,7 @@ export const parseExpect = (name: string) => {
       .split(';')
       .filter(Boolean)
       .map(entry => entry.split('='))
-      .map(([paramName, paramValue]) => [paramName, stringToBool(paramValue)])
+      .map(([paramName, paramValue]) => [paramName, parseParamValue(paramValue)])
   )
 
   return [expectationName, expectationParams] as const

--- a/src/components/blockly/mulang/expectations.ts
+++ b/src/components/blockly/mulang/expectations.ts
@@ -23,7 +23,7 @@ const nestedAlternativeStructureEDL =
 
 export const declarationDoesNotNestControlStructures = (declaration: string) =>
   newExpectation(
-    { isSuggestion: true, isForControlGroup: true, isScoreable: true },
+    { isSuggestion: true, isScoreable: true },
     `within \`${declaration}\` ${nestedAlternativeStructureEDL} && ${nestedControlStructureEDL('repeat')} && ${nestedControlStructureEDL('while')}`,
     doesNotNestControlStructuresId,
     { declaration }
@@ -82,7 +82,7 @@ export const countCallsWithin = (declaration: string) =>
 
 export const doSomething = (declaration: string) =>
   newExpectation(
-    { isSuggestion: true, isForControlGroup: true, isScoreable: true },
+    { isSuggestion: true, isScoreable: true },
     `${countCallsWithin(declaration)} >= 1`,
     doSomethingId,
     { declaration }
@@ -110,7 +110,7 @@ const declarationNotTooLong = (
   expectationName: string
 ) =>
   newExpectation(
-    { isSuggestion: true, isForControlGroup: true, isScoreable: true },
+    { isSuggestion: true, isScoreable: true },
     `${countCallsWithin(declaration)} <= ${limit - 1}`,
     expectationName,
     { declaration, limit }
@@ -133,7 +133,7 @@ export const doesNotUseRecursion = (declaration: string) =>
 export const nameWasChanged = (defaultProcedureName: string) =>
   (declaration: string) =>
     newSimpleCondition(
-      { isSuggestion: true, isScoreable: true, isForControlGroup: true },
+      { isSuggestion: true, isScoreable: true },
       !declaration.includes(defaultProcedureName),
       nameWasChangedId,
       { declaration }
@@ -171,10 +171,11 @@ export const conditionalRepetitionId = 'uses_conditional_repetition'
 export const simpleRepetitionId = 'uses_simple_repetition'
 
 export const usesConditionalAlternative = () =>
-  newGlobalExpectation({ isSuggestion: true, isForControlGroup: true, isScoreable: true }, 'uses if', conditionalAlternativeId)
+  newGlobalExpectation({ isSuggestion: true, isScoreable: true }, 'uses if', conditionalAlternativeId)
 
 export const usesConditionalRepetition = () =>
-  newGlobalExpectation({ isSuggestion: true, isForControlGroup: true, isScoreable: true }, 'uses while', conditionalRepetitionId)
+  newGlobalExpectation({ isSuggestion: true, isScoreable: true }, 'uses while', conditionalRepetitionId)
 
 export const usesSimpleRepetition = () =>
-  newGlobalExpectation({ isSuggestion: true, isForControlGroup: true, isScoreable: true }, 'uses repeat', simpleRepetitionId)
+  newGlobalExpectation({ isSuggestion: true, isScoreable: true }, 'uses repeat', simpleRepetitionId)
+export const isCritical = (result: any) => !!result.isCritical

--- a/src/components/blockly/mulang/mulangResults.ts
+++ b/src/components/blockly/mulang/mulangResults.ts
@@ -9,7 +9,6 @@ export type MulangExpectationResult = {
   isCritical?: boolean
   isSuggestion?: boolean
   isScoreable?: boolean
-  isForControlGroup?: boolean
   isRelatedToUsage?: boolean
   [key: string]: any
 }

--- a/src/components/blockly/mulang/pilasAst.ts
+++ b/src/components/blockly/mulang/pilasAst.ts
@@ -12,4 +12,4 @@ export const createReference = (name: string): MulangNode =>
   createNode('Reference', name)
 
 export const createEmptyNode = (): MulangNode =>
-  createNode('None', null)
+  createNode('None', [])

--- a/src/components/blockly/mulang/pilasMulang.ts
+++ b/src/components/blockly/mulang/pilasMulang.ts
@@ -23,10 +23,6 @@ const getBlockSiblings = (block: any): any[] => {
   return siblings
 }
 
-const isValue = (block: any) => {
-  return !!block.outputConnection
-}
-
 const isOperator = (block: any) => {
   return ['OpComparacion', 'OpAritmetica', 'logic_compare', 'math_arithmetic'].includes(block.type)
 }
@@ -72,7 +68,7 @@ const buildBlockAst = (block: any): any => {
 }
 
 const mulangParser = (block: any) => {
-  return pilasToMulangParsers[block.type] || searchAlias(block) || (isValue(block) ? referenceParser : applicationParser)
+  return pilasToMulangParsers[block.type] || searchAlias(block) || applicationParser
 }
 
 const buildSequenceAst = (firstBlock: any): any => {
@@ -205,12 +201,13 @@ const applicationParser = { tag: 'Application', parse: parseApplication }
 
 const pilasToMulangParsers: Record<string, any> = {
   [entryPointType]: entryPointParser,
-  Repetir: repeatParser,
   repetir: repeatParser,
+  Repetir: repeatParser,
   RepetirVacio: repeatParser,
+  hasta: untilParser,
+  Hasta: untilParser,
   Si: ifParser,
   SiNo: { ...ifParser, parse: parseIfElse },
-  Hasta: untilParser,
   math_number: numberParser,
   Numero: numberParser,
   procedures_defnoreturn: procedureParser,

--- a/src/components/challengeView/SceneButtons/EndChallengeDialog.tsx
+++ b/src/components/challengeView/SceneButtons/EndChallengeDialog.tsx
@@ -137,11 +137,12 @@ export const EndDialog = ({
           {scoreableResults.map((result, index) => {
             const passed = result.result === true
 
-            const text = t(`control_group.${result.id}`, {
+            const text = t(`scoreable.${result.id}`, {
               ns: 'mulang',
+              context: result.result ? 'passed' : 'failed',
               defaultValue: t(`suggestions.${result.id}`, {
                 ns: 'mulang',
-                defaultValue: result.id,
+                defaultValue: t('suggestions.check_out_this_block', { ns: 'mulang' }),
               }),
             })
 
@@ -158,8 +159,6 @@ export const EndDialog = ({
               >
                 {passed ? (
                   <CheckCircle fontSize="small" />
-                ) : result.id === 'main_too_long' || result.id === 'too_long' ? (
-                  <TouchAppOutlined fontSize="small" />
                 ) : (
                   <Error fontSize="small" />
                 )}

--- a/src/components/challengeView/SceneButtons/EndChallengeDialog.tsx
+++ b/src/components/challengeView/SceneButtons/EndChallengeDialog.tsx
@@ -30,7 +30,7 @@ const groupScoreableResults = (
     }, {})
 
   const combined = Object.values(grouped).map(group => {
-    return group.find(result => result.result) || group[0]
+    return group.find(result => !result.result) || group[0]
   })
 
   return [
@@ -45,11 +45,11 @@ const groupScoreableResults = (
 
 const markdownLite = (text: string) =>
   text
-    .replace(/<br\/?>/g, '\n')
-    .replace(/:point_right:/g, '👉')
-    .replace(/:repeat:/g, '🔁')
-    .replace(/\*\*/g, '')
-    .replace(/_/g, '')
+    .replace(/<br\/?>/gi, '\n')
+    .replace(/:point_right:/gi, '👉')
+    .replace(/:repeat:/gi, '🔁')
+    .replace(/\*\*(.*?)\*\*/g, '<b>$1</b>')
+    .replace(/_(.*?)_/g, '<i>$1</i>')
 
 export const EndDialog = ({
   showModal,
@@ -59,7 +59,7 @@ export const EndDialog = ({
   solved,
 }: EndDialogProps) => {
   const { t } = useTranslation(['challenge', 'mulang'])
-  const { theme } = useThemeContext()
+  const { theme, simpleReadModeEnabled } = useThemeContext()
 
   const scoreableResults = groupScoreableResults(mulangResults, solved)
   const failedScoreable = scoreableResults.filter(result => result.result === false)
@@ -137,7 +137,7 @@ export const EndDialog = ({
           {scoreableResults.map((result, index) => {
             const passed = result.result === true
 
-            const text = t(`scoreable.${result.id}`, {
+            let text = t(`scoreable.${result.id}`, {
               ns: 'mulang',
               context: result.result ? 'passed' : 'failed',
               defaultValue: t(`suggestions.${result.id}`, {
@@ -145,6 +145,10 @@ export const EndDialog = ({
                 defaultValue: t('suggestions.check_out_this_block', { ns: 'mulang' }),
               }),
             })
+
+            if (simpleReadModeEnabled) {
+              text = text.toUpperCase()
+            }
 
             return (
               <Stack
@@ -169,9 +173,8 @@ export const EndDialog = ({
                     color: passed ? 'success.main' : 'error.main',
                     whiteSpace: 'pre-line',
                   }}
-                >
-                  {markdownLite(text)}
-                </Typography>
+                  dangerouslySetInnerHTML={{ __html: markdownLite(text) }}
+                />
               </Stack>
             )
           })}

--- a/src/test/unit/components/blockly/mulang/astFactories.ts
+++ b/src/test/unit/components/blockly/mulang/astFactories.ts
@@ -1,0 +1,150 @@
+export function procedure(name: string, params: string[], ...seq: any[]) {
+  return {
+    tag: "Procedure",
+    contents: [
+      name,
+      [
+        equation(params, ...seq)
+      ]
+    ]
+  }
+}
+
+export function equation(params: string[], ...seq: any[]) {
+  return [
+    params.map(name => variable(name)),
+    body(...seq)
+  ]
+}
+
+export function variable(name: string) {
+  return {
+    tag: "VariablePattern",
+    contents: name
+  }
+}
+
+export function body(...seq: any[]) {
+  return {
+    tag: "UnguardedBody",
+    contents: sequence(...seq)
+  }
+}
+
+
+export function entryPoint(name: string, ...seq: any[]) {
+  return {
+    tag: "EntryPoint",
+    contents: [
+      name,
+      sequence(...seq)
+    ]
+  }
+}
+
+export function sequence(...seq: any[]) {
+  if (seq.length == 0) return none()
+  if (seq.length == 1) return seq[0]
+  return rawSequence(seq)
+}
+
+export function rawSequence(contents: any[]) {
+  return {
+    tag: "Sequence",
+    contents
+  }
+}
+
+export function reference(name: string) {
+  return {
+    tag: "Reference",
+    contents: name
+  }
+}
+
+export function application(name: string, ...params: any[]) {
+  return {
+    tag: "Application",
+    contents: [
+      reference(name),
+      params
+    ]
+  }
+}
+
+export function repeat(count: any, ...seq: any[]) {
+  return {
+    tag: "Repeat",
+    contents: [
+      count,
+      sequence(...seq)
+    ]
+  }
+}
+
+export function muIf(condition: any, ...seq: any[]) {
+  return {
+    tag: "If",
+    contents: [
+      condition,
+      sequence(...seq),
+      none()
+    ]
+  }
+}
+
+export function ifElse(condition: any, seqTrue: any, seqFalse: any) {
+  return {
+    tag: "If",
+    contents: [
+      condition,
+      seqTrue,
+      seqFalse
+    ]
+  }
+}
+
+export function muUntil(condition: any, ...seq: any[]) {
+  return {
+    tag: "While",
+    contents: [
+      primitiveApplication('Negation', condition),
+      sequence(...seq)
+    ]
+  }
+}
+
+export function number(n: number) {
+  return {
+    tag: "MuNumber",
+    contents: n
+  }
+}
+
+export function string(s: string) {
+  return {
+    tag: "MuString",
+    contents: s
+  }
+}
+
+export function none() {
+  return {
+    tag: "None",
+    contents: []
+  }
+}
+
+function primitive(name: string) {
+  return {
+    tag: "Primitive",
+    contents: name
+  }
+}
+
+function primitiveApplication(name: string, ...params: any[]) {
+  return {
+    tag: "Application",
+    contents: [primitive(name), params]
+  }
+}

--- a/src/test/unit/components/blockly/mulang/challengeExpectations.test.ts
+++ b/src/test/unit/components/blockly/mulang/challengeExpectations.test.ts
@@ -1,0 +1,107 @@
+import { mergeConfigurations, configToExpectation, expectationFor } from '../../../../../components/blockly/mulang/challengeExpectations'
+import * as Blockly from 'blockly/core'
+
+// Mock getPathToChallenge
+jest.mock('../../../../../staticData/challenges', () => ({
+  getPathToChallenge: (id: string) => {
+    if (id === 'challenge_with_hierarchy') {
+      return {
+        book: { expectations: { decomposition: true } },
+        chapter: { expectations: { simpleRepetition: true } },
+        group: { expectations: {} },
+        challenge: { expectations: { decomposition: false } }
+      }
+    }
+    return { book: null, chapter: null, group: null, challenge: null }
+  }
+}))
+
+describe('Challenge Expectations', () => {
+
+  const expectationsConfigMock = {
+    decomposition: true,
+    simpleRepetition: true,
+    conditionalAlternative: true
+  }
+
+  const workspaceMock = {} as Blockly.WorkspaceSvg
+  const defaultProcedureName = 'Hacer algo'
+
+  describe('mergeConfigurations', () => {
+    it('merged expectations for a single expectation configuration', () => {
+      expect(mergeConfigurations([expectationsConfigMock])).toEqual(expectationsConfigMock)
+    })
+
+    it('merged expectations for no expectations configuration should be an empty object', () => {
+      expect(mergeConfigurations([])).toEqual({})
+    })
+
+    it('merged expectations for multiple configurations without keys in common', () => {
+      const conditionalAlternativeConfig = {
+        conditionalAlternative: true
+      }
+      const mergedConfig = {
+        decomposition: true,
+        simpleRepetition: true,
+        conditionalAlternative: true
+      }
+      expect(mergeConfigurations([expectationsConfigMock, conditionalAlternativeConfig])).toEqual(mergedConfig)
+    })
+
+    it('merged expectations for multiple configurations with keys in common should prioritize values with higher priority', () => {
+      const configWithHigherPriority = {
+        decomposition: false
+      }
+      const mergedConfig = {
+        decomposition: false,
+        simpleRepetition: true,
+        conditionalAlternative: true
+      }
+      expect(mergeConfigurations([expectationsConfigMock, configWithHigherPriority])).toEqual(mergedConfig)
+    })
+  })
+
+  describe('configToExpectation', () => {
+    it('multiple nonexistent expectations ids are transformed to a noExpectation (empty)', () => {
+      const nonexistenteEpectations = {
+        foo: true,
+        bar: false,
+        baz: true
+      }
+      const result = configToExpectation(nonexistenteEpectations, workspaceMock, defaultProcedureName)
+      expect(result).toBe('')
+    })
+
+    it('if a challenge does not define expectations, noExpectation is applied', () => {
+      const result = configToExpectation({}, workspaceMock, defaultProcedureName)
+      expect(result).toBe('')
+    })
+    
+    it('applies valid expectations successfully', () => {
+      // Test that it returns a string when valid configs are passed
+      const result = configToExpectation({ simpleRepetition: true }, workspaceMock, defaultProcedureName)
+      expect(typeof result).toBe('string')
+      expect(result.length).toBeGreaterThan(0)
+      expect(result).toContain('uses repeat')
+    })
+  })
+
+  describe('expectationFor', () => {
+    it('expectations from book, chapter, group and challenge should be combined', () => {
+      const challenge = { id: 'challenge_with_hierarchy' }
+      const result = expectationFor(challenge, workspaceMock, defaultProcedureName)
+      
+      // simpleRepetition should be true (from chapter)
+      // decomposition should be false (challenge overrides book)
+      expect(result).toContain('uses repeat')
+      expect(result).not.toContain('does not nest control structures') // part of decomposition
+    })
+
+    it('returns empty expectation for a challenge with no hierarchy or expectations', () => {
+      const challenge = { id: 'some_other_challenge' }
+      const result = expectationFor(challenge, workspaceMock, defaultProcedureName)
+      expect(result).toBe('')
+    })
+  })
+
+})

--- a/src/test/unit/components/blockly/mulang/mulangExpectations.test.ts
+++ b/src/test/unit/components/blockly/mulang/mulangExpectations.test.ts
@@ -1,0 +1,367 @@
+import mulang from 'mulang'
+import { entryPointType } from '../../../../../components/blockly/mulang/blockUtils'
+import { 
+  doSomething, 
+  isUsed, 
+  isUsedFromMain, 
+  notTooLong, 
+  parseExpect, 
+  doesNotUseRecursion, 
+  stringify, 
+  isCritical, 
+  doesNotUseRecursionId, 
+  newExpectation, 
+  countCallsWithin, 
+  nameWasChanged, 
+  usesConditionalAlternative, 
+  usesConditionalRepetition, 
+  usesSimpleRepetition, 
+  declarationDoesNotNestControlStructures 
+} from '../../../../../components/blockly/mulang/expectations'
+import { procedure, entryPoint, rawSequence, application, muIf, ifElse, none, muUntil, repeat, number } from './astFactories'
+
+describe('Mulang Expectations', () => {
+
+  const declaration = 'PROCEDURE'
+  const limit = 3
+
+  // EDL
+  expectationTestOk('doSomething', doSomething(declaration), [
+    procedure(declaration, [],
+      application('PRIMITIVE')
+    )
+  ])
+
+  expectationTestOk('doSomething', doSomething(declaration), [
+    procedure(declaration, [],
+      application(declaration)
+    )
+  ], 'Recursion should count as doing something')
+
+  expectationTestFail('doSomething', doSomething('EMPTY'), [
+    procedure('EMPTY', [])
+  ])
+
+  expectationTestOk('isUsed', isUsed('EMPTY'), [
+    entryPoint(entryPointType,
+      application('EMPTY')
+    ),
+    procedure('EMPTY', [])
+  ])
+
+  expectationTestOk('isUsed (from procedure)', isUsed('EMPTY'), [
+    procedure(declaration, [],
+      application('EMPTY')
+    ),
+    procedure('EMPTY', [])
+  ])
+
+  expectationTestFail('isUsed', isUsed('EMPTY'), [
+    entryPoint(entryPointType),
+    procedure('EMPTY', [])
+  ])
+
+  expectationTestOk('isUsedFromMain', isUsedFromMain('EMPTY'), [
+    entryPoint(entryPointType,
+      application('EMPTY')
+    ),
+    procedure('EMPTY', [])
+  ])
+
+  expectationTestFail('isUsedFromMain', isUsedFromMain('EMPTY'), [
+    entryPoint(entryPointType),
+    procedure('EMPTY', []),
+    procedure(declaration, [],
+      application('EMPTY')
+    )
+  ])
+
+  expectationTestOk('notTooLong', notTooLong(limit)(entryPointType), [
+    entryPoint(entryPointType,
+      application('PRIMITIVE'),
+      application('PRIMITIVE'),
+    ),
+  ])
+
+  expectationTestFail('notTooLong', notTooLong(limit)(entryPointType), [
+    entryPoint(entryPointType,
+      application('PRIMITIVE'),
+      application('PRIMITIVE'),
+      application('PRIMITIVE'),
+    )
+  ])
+
+  expectationTestFail('notTooLong', notTooLong(limit)(declaration), [
+    procedure(declaration, [],
+      application(declaration),
+      application(declaration),
+      application(declaration)
+    )
+  ], 'Recursive calls should count as being too long')
+  
+  expectationTestFail('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(entryPointType), [
+    entryPoint(entryPointType,
+      muIf(none(),
+        muUntil(none(), none())
+      )
+    )
+  ])
+
+  expectationTestFail('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(entryPointType), [
+    entryPoint(entryPointType,
+      muUntil(none(),
+        muIf(none(), none())
+      )
+    )
+  ])
+
+  expectationTestFail('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(entryPointType), [
+    entryPoint(entryPointType,
+      repeat(number(3),
+        muIf(none(), none())
+      )
+    )
+  ])
+
+  expectationTestFail('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(declaration), [
+    procedure(declaration, [], 
+      muIf(none(),
+        repeat(number(3), none()))  
+    )
+  ])
+
+  expectationTestFail('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(declaration), [
+    procedure(declaration, [], 
+      muIf(none(),
+        muIf(none())) 
+    )
+  ])
+
+  expectationTestFail('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(declaration), [
+    procedure(declaration, [], 
+      muIf(none(),
+        muUntil(none(), none())) 
+    )
+  ])
+
+  expectationTestOk('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(declaration), [
+    procedure(declaration, [],
+      muIf(none(),
+      application("PROCEDURE2"))
+    ),
+    procedure("PROCEDURE2", [],
+      muIf(none())
+    )
+  ])
+
+  expectationTestOk('doesNotUseRecursion', doesNotUseRecursion(declaration), [
+    procedure(declaration, [],
+      application("PROCEDURE2")
+    ),
+    procedure("PROCEDURE2", [])
+  ])
+
+  expectationTestFail('usesConditionalAlternative', usesConditionalAlternative(), [
+    entryPoint(entryPointType,
+      application('EMPTY')
+    )
+  ])
+
+  expectationTestOk('usesSimpleConditionalAlternative', usesConditionalAlternative(), [
+    entryPoint(entryPointType,
+      muIf(none())
+    )
+  ])
+
+  expectationTestOk('usesCompleteConditionalAlternative', usesConditionalAlternative(), [
+    entryPoint(entryPointType,
+      ifElse(none(), none(), none())
+    )
+  ])
+
+  expectationTestOk('Global expectation is transitive through a procedure', usesConditionalAlternative(), [
+    entryPoint(entryPointType,
+      application('USES_IF')
+    ),
+    procedure('USES_IF', [],
+      muIf(none())
+    )
+  ])
+
+  expectationTestFail('usesCondicionalRepetition', usesConditionalRepetition(), [
+    entryPoint(entryPointType,
+      application('EMPTY')
+    )
+  ])
+
+  expectationTestOk('usesCondicionalRepetition', usesConditionalRepetition(), [
+    entryPoint(entryPointType,
+      muUntil(none(), none())
+    )
+  ])
+
+  // Direct recursion
+  expectationTestFail('doesNotUseRecursion', doesNotUseRecursion(declaration), [
+    procedure(declaration, [],
+      application(declaration)
+    )
+  ])
+
+  expectationTestFail('usesSimpleRepetition', usesSimpleRepetition(), [
+    entryPoint(entryPointType,
+      application('EMPTY')
+    )
+  ])
+
+  expectationTestOk('usesSimpleRepetition', usesSimpleRepetition(), [
+    entryPoint(entryPointType,
+      repeat(number(3), none())
+    )
+  ])
+
+  // Indirect recursion
+  expectationTestFail('doesNotUseRecursion', doesNotUseRecursion(declaration), [
+    procedure(declaration, [],
+      application("PROCEDURE2")
+    ),
+    procedure("PROCEDURE2", [],
+      application(declaration)
+    )
+  ], 'Indirect recursion should count as recursion')
+
+  expectationTestFail('doesNotUseRecursion', doesNotUseRecursion(declaration), [
+    procedure(declaration, [],
+      application(declaration),
+      application("PROCEDURE2")
+    ),
+    procedure("PROCEDURE2", [],
+      application('PRIMITIVE'))
+  ], 'Direct recursion with another procedure call should count as recursion')
+
+  expectationTestOk('countCallsWithin', newExpectation(`${countCallsWithin(declaration)} = 2`, 'counts', { declaration }), [
+    procedure(declaration, [],
+      application("PROCEDURE2"),
+      application(declaration)
+    ),
+    procedure("PROCEDURE2", [])
+  ], 'countCallsWithin includes recursive calls')
+
+  function expectationTestOk(expectationName: string, expectation: string, astNodes: any[], testName = '') {
+    expectationTest(expectationName, expectation, astNodes, true, testName)
+  }
+
+  function expectationTestFail(expectationName: string, expectation: string, astNodes: any[], testName = '') {
+    expectationTest(expectationName, expectation, astNodes, false, testName)
+  }
+
+  function expectationTest(expectationName: string, edl: string, astNodes: any[], shouldPass: boolean, testName = '') {
+    let workspaceMock: Blockly.WorkspaceSvg
+
+    beforeEach(() => {
+      workspaceMock = { 
+        getTopBlocks: jest.fn(),
+        getAllBlocks: jest.fn().mockReturnValue([])
+      } as any as Blockly.WorkspaceSvg
+    })
+    it(`Expectation ${expectationName} - ${testName || (shouldPass ? 'ok' : 'fail')}`, () => {
+      const results: any[] = (mulang as any)
+        .astCode(rawSequence(astNodes))
+        .customExpect(edl)
+      
+      const mulangResult = results.every(([, result]) => result)
+
+      if (shouldPass) {
+        expect(mulangResult).toBe(true)
+      } else {
+        expect(mulangResult).toBe(false)
+      }
+    })
+  }
+
+  // IDs tests
+  expectationKeyTest('doSomething', doSomething(declaration),
+    ['do_something', { declaration, isSuggestion: true, isScoreable: true }]
+  )
+
+  expectationKeyTest('isUsed', isUsed(declaration),
+    ['is_used', { declaration, isSuggestion: true, isRelatedToUsage: true }]
+  )
+
+  expectationKeyTest('isUsedFromMain', isUsedFromMain(declaration),
+    ['is_used_from_main', { declaration, isSuggestion: true, isRelatedToUsage: true }]
+  )
+
+  expectationKeyTest('notTooLong', notTooLong(limit)(declaration),
+    ['too_long', { declaration, limit: String(limit), isSuggestion: true, isScoreable: true }]
+  )
+
+  expectationKeyTest('declarationDoesNotNestControlStructures', declarationDoesNotNestControlStructures(declaration),
+    ['does_not_nest_control_structures', { declaration, isSuggestion: true, isScoreable: true }]
+  )
+
+  expectationKeyTest('usesConditionalAlternative', usesConditionalAlternative(),
+    ['uses_conditional_alternative', { declaration: entryPointType, isSuggestion: true, isScoreable: true }]
+  )
+
+  expectationKeyTest('usesConditionalRepetition', usesConditionalRepetition(),
+    ['uses_conditional_repetition', { declaration: entryPointType, isSuggestion: true, isScoreable: true }]
+  )
+
+  expectationKeyTest('usesSimpleRepetition', usesSimpleRepetition(),
+    ['uses_simple_repetition', { declaration: entryPointType, isSuggestion: true, isScoreable: true }]
+  )
+
+  expectationKeyTest('doesNotUseRecursion', doesNotUseRecursion(declaration),
+    ['does_not_use_recursion', { declaration, isCritical: true, isSuggestion: true }]
+  )
+
+  function expectationKeyTest(expectationName: string, edl: string, ...expectedIds: any[]) {
+    it(`ID for ${expectationName}`, () => {
+      const fullId = (mulang as any)
+        .astCode(rawSequence([]))
+        .customExpect(edl)
+        .map(([name]: any) => parseExpect(window.atob(name)))
+
+      expect(fullId).toEqual(expectedIds)
+    })
+  }
+
+  const expectationNameVar = 'expectation_id'
+  const stringifiedExpectationId = 'expectation_id|'
+  const stringifiedExpectationOneOpt = 'expectation_id|declaration=PROCEDURE'
+  const stringifiedExpectationMultipleOpt = 'expectation_id|declaration=PROCEDURE;b=foo'
+
+  // Utils
+  it('stringify with expectation id only', () => {
+    expect(stringify('expectation_id', {})).toBe(stringifiedExpectationId)
+  })
+
+  it('stringify with one option', () => {
+    expect(stringify('expectation_id', { declaration })).toBe(stringifiedExpectationOneOpt)
+  })
+
+  it('stringify with multiple options', () => {
+    expect(stringify('expectation_id', { declaration, b: 'foo' })).toBe(stringifiedExpectationMultipleOpt)
+  })
+
+  it('parseExpect with expectation name only', () => {
+    expect(parseExpect(stringifiedExpectationId)).toEqual([expectationNameVar, { "": undefined }])
+  })
+
+  it('parseExpect with expectation name and one param', () => {
+    expect(parseExpect(stringifiedExpectationOneOpt)).toEqual([expectationNameVar, { declaration: declaration }])
+  })
+
+  it('parseExpect with expectation name and multiple params', () => {
+    expect(parseExpect(stringifiedExpectationMultipleOpt)).toEqual([expectationNameVar, { declaration: declaration, b: 'foo' }])
+  })
+
+  it('critical expectation is critical', () => {
+    expect(isCritical({ id: doesNotUseRecursionId, isCritical: true, result: false })).toBe(true)
+  })
+
+  it('non critical expectation is not critical', () => {
+    expect(isCritical({ id: 'is_used', result: false })).toBe(false)
+  })
+
+})

--- a/src/test/unit/components/blockly/mulang/mulangResults.test.ts
+++ b/src/test/unit/components/blockly/mulang/mulangResults.test.ts
@@ -1,0 +1,64 @@
+import { combineUsageResults, isUsedId, isUsedFromMainId, MulangExpectationResult } from '../../../../../components/blockly/mulang/mulangResults'
+
+describe('Mulang Results - combineUsage', () => {
+
+  const isUsedDescription = 'IS USED DESC'
+  const isUsedFromMainDescription = 'IS USED FROM MAIN DESC'
+
+  const createResult = (id: string, result: boolean, description: string, declaration?: string, isRelatedToUsage = true): MulangExpectationResult => ({
+    id, result, description, declaration, isRelatedToUsage
+  })
+
+  it('Combine two usage results of a procedure that is not used from anywhere', () => {
+    const isUsedResult = createResult(isUsedId, false, isUsedDescription)
+    const isUsedFromMainResult = createResult(isUsedFromMainId, false, isUsedFromMainDescription)
+
+    expect(combineUsageResults([isUsedResult, isUsedFromMainResult])).toEqual([
+      createResult(isUsedId, false, isUsedDescription)
+    ])
+  })
+
+  it('Combine two usage results of a procedure that is used from another procedure but not from main', () => {
+    const isUsedResult = createResult(isUsedId, true, isUsedDescription)
+    const isUsedFromMainResult = createResult(isUsedFromMainId, false, isUsedFromMainDescription)
+
+    expect(combineUsageResults([isUsedResult, isUsedFromMainResult])).toEqual([
+      createResult(isUsedFromMainId, false, isUsedFromMainDescription)
+    ])
+  })
+
+  it('Combine two usage results of a procedure that is used', () => {
+    const isUsedResult = createResult(isUsedId, true, isUsedDescription)
+    const isUsedFromMainResult = createResult(isUsedFromMainId, true, isUsedFromMainDescription)
+
+    expect(combineUsageResults([isUsedResult, isUsedFromMainResult])).toEqual([
+      createResult(isUsedFromMainId, true, isUsedFromMainDescription)
+    ])
+  })
+
+  it('Combine usage results multiple', () => {
+    const flyProcedure = 'fly'
+    const jumpProcedure = 'jump'
+    const ifResult = createResult('if', false, '', 'conditional', false)
+    const whileResult = createResult('while', true, '', 'loop', false)
+    const flyIsUsed = createResult(isUsedId, true, isUsedDescription, flyProcedure)
+    const flyIsUsedFromMain = createResult(isUsedFromMainId, false, isUsedFromMainDescription, flyProcedure)
+    const jumpIsUsed = createResult(isUsedId, true, isUsedDescription, jumpProcedure)
+    const jumpIsUsedFromMain = createResult(isUsedFromMainId, true, isUsedFromMainDescription, jumpProcedure)
+    
+    // According to the original tests, combined results are grouped
+    const flyIsUsedCombined = createResult(isUsedFromMainId, false, isUsedFromMainDescription, flyProcedure)
+    const jumpIsUsedCombined = createResult(isUsedFromMainId, true, isUsedFromMainDescription, jumpProcedure)
+
+    const result = combineUsageResults([ifResult, flyIsUsed, flyIsUsedFromMain, whileResult, jumpIsUsed, jumpIsUsedFromMain])
+    
+    expect(result).toEqual(expect.arrayContaining([
+      ifResult, 
+      whileResult, 
+      flyIsUsedCombined, 
+      jumpIsUsedCombined
+    ]))
+    expect(result).toHaveLength(4)
+  })
+
+})

--- a/src/test/unit/components/blockly/mulang/pilasMulang.test.ts
+++ b/src/test/unit/components/blockly/mulang/pilasMulang.test.ts
@@ -1,0 +1,807 @@
+import * as Blockly from 'blockly/core'
+import 'blockly/blocks'
+import { parseAll } from '../../../../../components/blockly/mulang/pilasMulang'
+import { procedure, entryPoint, sequence, rawSequence, reference, application, repeat, muIf, ifElse, muUntil, number, string, none } from './astFactories'
+
+const defineBlocksFromXml = (xmlStrs: string[]) => {
+  xmlStrs.forEach(xmlStr => {
+    const dom = Blockly.utils.xml.textToDom(`<xml>${xmlStr}</xml>`)
+    const blocks = Array.from(dom.querySelectorAll('block, shadow'))
+    for (let i = 0; i < blocks.length; i++) {
+      const type = blocks[i].getAttribute('type')
+      if (!type || Blockly.Blocks[type]) continue
+
+      // Does this block appear inside a <value>?
+      const isValue = Array.from(dom.getElementsByTagName('value')).some(v => Array.from(v.children).some(c => c === blocks[i] || c.getAttribute('type') === type))
+
+      const statementNames = Array.from(blocks[i].children).filter(c => c.tagName === 'statement').map(s => s.getAttribute('name'))
+      const valueNames = Array.from(blocks[i].children).filter(c => c.tagName === 'value').map(v => v.getAttribute('name'))
+      const fieldNames = Array.from(blocks[i].children).filter(c => c.tagName === 'field').map(f => f.getAttribute('name'))
+      const mutations = Array.from(blocks[i].children).filter(c => c.tagName === 'mutation')
+
+      Blockly.Blocks[type] = {
+        init: function() {
+          if (isValue || type === 'variables_get') {
+            this.setOutput(true)
+          } else {
+            this.setPreviousStatement(true)
+            this.setNextStatement(true)
+          }
+          
+          statementNames.forEach(n => n && this.appendStatementInput(n))
+          valueNames.forEach(n => n && this.appendValueInput(n))
+          fieldNames.forEach(n => n && this.appendDummyInput().appendField(new Blockly.FieldTextInput(''), n))
+          
+          if (mutations.length > 0) {
+            this.mutator = { args_: [], argumentVarModels_: [] }
+          }
+        }
+      }
+    }
+  })
+}
+// Additional manual blocks that need specific mocked methods for pilasMulang.ts
+Blockly.Blocks['procedures_defnoreturn'] = {
+  init: function() {
+    this.appendDummyInput().appendField(new Blockly.FieldTextInput(''), 'NAME')
+    this.appendStatementInput('STACK')
+    this.arguments_ = []
+  },
+  getProcedureDef: function() {
+    const name = this.getFieldValue('NAME')
+    return [name, this.arguments_, false]
+  },
+  domToMutation: function(xmlElement: Element) {
+    const args = []
+    for (let i = 0; i < xmlElement.childNodes.length; i++) {
+      const child = xmlElement.childNodes[i] as Element
+      if (child.tagName && child.tagName.toLowerCase() === 'arg') {
+        args.push(child.getAttribute('name'))
+      }
+    }
+    this.arguments_ = args
+    for (let i = 0; i < args.length; i++) {
+      if (!this.getInput('ARG' + i)) {
+        this.appendDummyInput('ARG' + i).appendField(new Blockly.FieldTextInput(args[i]), 'ARG' + i)
+      }
+    }
+  }
+}
+
+Blockly.Blocks['procedures_callnoreturn'] = {
+  init: function() {
+    this.setPreviousStatement(true)
+    this.setNextStatement(true)
+  },
+  getProcedureCall: function() {
+    return this.mutationName_ || 'Hacer algo'
+  },
+  domToMutation: function(xmlElement: Element) {
+    this.mutationName_ = xmlElement.getAttribute('name')
+    const args = Array.from(xmlElement.childNodes).filter((c: any) => c.tagName && c.tagName.toLowerCase() === 'arg')
+    for (let i = 0; i < args.length; i++) {
+      if (!this.getInput('ARG' + i)) {
+        this.appendValueInput('ARG' + i)
+      }
+    }
+  }
+}
+
+Blockly.Blocks['variables_get'] = {
+  init: function() {
+    this.setOutput(true)
+    this.appendDummyInput().appendField(new Blockly.FieldTextInput(''), 'VAR')
+  },
+  domToMutation: function(xmlElement: Element) {
+    this.varName_ = xmlElement.getAttribute('var')
+    this.setFieldValue(this.varName_, 'VAR')
+  }
+}
+
+Blockly.Blocks['param_get'] = Blockly.Blocks['variables_get']
+
+
+function textToBlock(workspace: Blockly.Workspace, code: string) {
+  defineBlocksFromXml([code])
+  const dom = Blockly.utils.xml.textToDom(`<xml>${code}</xml>`)
+  Blockly.Xml.domToWorkspace(dom, workspace)
+}
+
+describe('Mulang Parse', () => {
+
+  let workspace: Blockly.Workspace
+
+  beforeEach(() => {
+    workspace = new Blockly.Workspace()
+  })
+
+  afterEach(() => {
+    workspace.dispose()
+  })
+
+  function mulangParseBlockTest(name: string, code: string, expectedAst: any) {
+    it(`Should parse ${name} block`, () => {
+      textToBlock(workspace, code)
+      const ast = parseAll(workspace)
+      // AST from parseAll is always a Sequence, so we extract the first element for block tests
+      expect(ast.contents[0]).toEqual(expectedAst)
+    })
+  }
+
+  function mulangParseWorkspaceTest(description: string, definitions: string[], expectedAst: any[]) {
+    it(`Should parse workspace with ${description}`, () => {
+      definitions.forEach(code => textToBlock(workspace, code))
+      const ast = parseAll(workspace)
+      expect(ast).toEqual(rawSequence(expectedAst))
+    })
+  }
+
+  const emptyProgram = `
+  <block type="al_empezar_a_ejecutar">
+    <statement name="program">
+      <shadow type="required_statement"></shadow>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('emptyProgram', emptyProgram,
+    entryPoint(
+      "al_empezar_a_ejecutar"
+    )
+  )
+
+  const simpleProgram = `
+  <block type="al_empezar_a_ejecutar">
+    <statement name="program">
+      <shadow type="required_statement"></shadow>
+      <block type="MoverACasillaDerecha"></block>
+    </statement>
+  </block>
+  `
+  const simpleProgramAST =
+    entryPoint(
+      "al_empezar_a_ejecutar",
+      application("MoverACasillaDerecha")
+    )
+  mulangParseBlockTest('simpleProgram', simpleProgram, simpleProgramAST)
+
+  const al_empezar_a_ejecutar = `
+  <block type="al_empezar_a_ejecutar">
+    <statement name="program">
+      <shadow type="required_statement"></shadow>
+      <block type="MoverACasillaDerecha">
+        <next>
+          <block type="MoverACasillaIzquierda">
+            <next>
+              <block type="MoverACasillaDerecha"></block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('al_empezar_a_ejecutar', al_empezar_a_ejecutar,
+    entryPoint(
+      "al_empezar_a_ejecutar",
+      application("MoverACasillaDerecha"),
+      application("MoverACasillaIzquierda"),
+      application("MoverACasillaDerecha")
+    )
+  )
+
+  const repetir = `
+  <block type="repetir">
+    <value name="count">
+      <block type="math_number">
+        <field name="NUM">10</field>
+      </block>
+    </value>
+    <statement name="block">
+      <block type="MoverACasillaIzquierda">
+        <next>
+          <block type="MoverACasillaDerecha"></block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('repetir', repetir,
+    repeat(
+      number(10),
+      application("MoverACasillaIzquierda"),
+      application("MoverACasillaDerecha")
+    )
+  )
+
+  const si = `
+  <block type="Si">
+    <value name="condition">
+      <block type="HayChurrasco"></block>
+    </value>
+    <statement name="block">
+      <block type="MoverACasillaDerecha">
+        <next>
+          <block type="ComerChurrasco"></block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('si', si,
+    muIf(
+      application("HayChurrasco"),
+      application("MoverACasillaDerecha"),
+      application("ComerChurrasco")
+    )
+  )
+
+  const sino = `
+  <block type="SiNo">
+    <value name="condition">
+      <shadow type="required_value"></shadow>
+      <block type="HayTomate"></block>
+    </value>
+    <statement name="block1">
+      <shadow type="required_statement"></shadow>
+      <block type="AgarrarTomate">
+        <next>
+          <block type="MoverACasillaIzquierda"></block>
+        </next>
+      </block>
+    </statement>
+    <statement name="block2">
+      <shadow type="required_statement"></shadow>
+      <block type="AgarrarLechuga">
+        <next>
+          <block type="MoverACasillaIzquierda"></block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('sino', sino,
+    ifElse(
+      application("HayTomate"),
+      sequence(
+        application("AgarrarTomate"),
+        application("MoverACasillaIzquierda")
+      ),
+      sequence(
+        application("AgarrarLechuga"),
+        application("MoverACasillaIzquierda")
+      )
+    )
+  )
+
+  const hasta = `
+  <block type="Hasta">
+    <value name="condition">
+      <shadow type="required_value"></shadow>
+      <block type="TocandoFinal"></block>
+    </value>
+    <statement name="block">
+      <shadow type="required_statement"></shadow>
+      <block type="EncenderLuz">
+        <next>
+          <block type="MoverACasillaAbajo"></block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('hasta', hasta,
+    muUntil(
+      application("TocandoFinal"),
+      application("EncenderLuz"),
+      application("MoverACasillaAbajo")
+    )
+  )
+
+  const applicationWithParameter = `
+  <block type="MoverA">
+    <value name="direccion">
+      <shadow type="required_value"></shadow>
+      <block type="ParaLaDerecha"></block>
+    </value>
+  </block>
+  `
+  mulangParseBlockTest('application with reference param', applicationWithParameter,
+    application("MoverA", application("ParaLaDerecha"))
+  )
+
+  const applicationWithApplicationParameter = `
+  <block type="DibujarLado">
+    <value name="longitud">
+      <shadow type="required_value"></shadow>
+      <block type="OpAritmetica">
+        <field name="OP">ADD</field>
+        <value name="A">
+          <shadow type="required_value"></shadow>
+          <block type="math_number">
+            <field name="NUM">10</field>
+          </block>
+        </value>
+        <value name="B">
+          <shadow type="required_value"></shadow>
+          <block type="math_number">
+            <field name="NUM">100</field>
+          </block>
+        </value>
+      </block>
+    </value>
+  </block>
+  `
+  mulangParseBlockTest('application with application param', applicationWithApplicationParameter,
+    application("DibujarLado",
+      application("ADD",
+        number(10),
+        number(100)
+      )
+    )
+  )
+
+  const applicationWithTextParameter = `
+  <block type="EscribirTextoDadoEnOtraCuadricula">
+    <field name="texto">A</field>
+  </block>
+  `
+  mulangParseBlockTest('application with text param', applicationWithTextParameter,
+    application("EscribirTextoDadoEnOtraCuadricula", string("A"))
+  )
+
+  const operator = `
+  <block type="Si">
+    <value name="condition">
+      <shadow type="required_value"></shadow>
+      <block type="OpComparacion">
+        <field name="OP">EQ</field>
+        <value name="A">
+          <shadow type="required_value"></shadow>
+          <block type="Numero">
+            <field name="NUM">0</field>
+          </block>
+        </value>
+        <value name="B">
+          <shadow type="required_value"></shadow>
+          <block type="Numero">
+            <field name="NUM">0</field>
+          </block>
+        </value>
+      </block>
+    </value>
+    <statement name="block">
+      <shadow type="required_statement"></shadow>
+      <block type="MoverACasillaDerecha">
+        <next>
+          <block type="PrenderFogata"></block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('operator', operator,
+    muIf(
+      application("EQ",
+        number(0),
+        number(0)
+      ),
+      application("MoverACasillaDerecha"),
+      application("PrenderFogata")
+    )
+  )
+
+
+
+  const procedureDefinition = `
+  <block type="procedures_defnoreturn">
+    <field name="NAME">esquina</field>
+    <statement name="STACK">
+      <shadow type="required_statement"></shadow>
+      <block type="DibujarLado">
+        <value name="longitud">
+          <shadow type="required_value"></shadow>
+          <block type="math_number">
+            <field name="NUM">100</field>
+          </block>
+        </value>
+        <next>
+          <block type="GirarGrados">
+            <value name="grados">
+              <shadow type="required_value"></shadow>
+              <block type="math_number">
+                <field name="NUM">90</field>
+              </block>
+            </value>
+            <next>
+              <block type="DibujarLado">
+                <value name="longitud">
+                  <shadow type="required_value"></shadow>
+                  <block type="math_number">
+                    <field name="NUM">100</field>
+                  </block>
+                </value>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  const procedureAST =
+    procedure("esquina", [],
+      application("DibujarLado", number(100)),
+      application("GirarGrados", number(90)),
+      application("DibujarLado", number(100))
+    )
+  mulangParseBlockTest('procedure', procedureDefinition, procedureAST)
+
+  const procedureWithParams = `
+  <block type="procedures_defnoreturn">
+    <mutation>
+      <arg name="lado"></arg>
+      <arg name="angulo"></arg>
+    </mutation>
+    <field name="NAME">esquina</field>
+    <field name="ARG0">lado</field>
+    <field name="ARG1">angulo</field>
+    <statement name="STACK">
+      <shadow type="required_statement"></shadow>
+      <block type="DibujarLado">
+        <value name="longitud">
+          <shadow type="required_value"></shadow>
+          <block type="variables_get">
+            <mutation var="lado" parent=":2hb{1CYnYqL(S0v_ou"></mutation>
+          </block>
+        </value>
+        <next>
+          <block type="GirarGrados">
+            <value name="grados">
+              <shadow type="required_value"></shadow>
+              <block type="variables_get">
+                <mutation var="angulo" parent=":2hb{1CYnYqL(S0v_ou"></mutation>
+              </block>
+            </value>
+            <next>
+              <block type="DibujarLado">
+                <value name="longitud">
+                  <shadow type="required_value"></shadow>
+                  <block type="variables_get">
+                    <mutation var="lado" parent=":2hb{1CYnYqL(S0v_ou"></mutation>
+                  </block>
+                </value>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('procedure with params', procedureWithParams,
+    procedure("esquina", ["lado", "angulo"],
+      application("DibujarLado", reference("lado")),
+      application("GirarGrados", reference("angulo")),
+      application("DibujarLado", reference("lado"))
+    )
+  )
+
+  const procedureCall = `
+  <block type="procedures_callnoreturn">
+    <mutation name="Hacer algo"></mutation>
+  </block>
+  `
+  mulangParseBlockTest('procedureCall', procedureCall,
+    application("Hacer algo")
+  )
+
+  const procedureCallWithParam = `
+  <block type="procedures_callnoreturn" disabled="true">
+    <mutation name="Hacer algo2">
+      <arg name="parámetro 1"></arg>
+    </mutation>
+    <value name="ARG0">
+      <shadow type="required_value"></shadow>
+      <block type="math_number">
+        <field name="NUM">90</field>
+      </block>
+    </value>
+  </block>
+  `
+  mulangParseBlockTest('procedureCallWithParam', procedureCallWithParam,
+    application("Hacer algo2", number(90))
+  )
+
+  const parameter = `
+  <block type="GirarGrados">
+    <value name="grados">
+      <shadow type="required_value"></shadow>
+      <block type="variables_get">
+        <mutation var="angulo" parent=":2hb{1CYnYqL(S0v_ou"></mutation>
+      </block>
+    </value>
+  </block>
+  `
+  mulangParseBlockTest('parameter', parameter,
+    application("GirarGrados",
+      reference("angulo")
+    )
+  )
+
+  const alias = `
+  <block type="Si">
+    <value name="condition">
+      <shadow type="required_value"></shadow>
+    </value>
+    <statement name="block">
+      <shadow type="required_statement"></shadow>
+    </statement>
+  </block>
+  `
+  mulangParseBlockTest('alias', alias,
+    muIf(none())
+  )
+
+  mulangParseWorkspaceTest(`one block`, [simpleProgram], [simpleProgramAST])
+
+  mulangParseWorkspaceTest(`every blocks`, [simpleProgram, procedureDefinition], [simpleProgramAST, procedureAST])
+
+  const evilSolution = [`
+  <block type="al_empezar_a_ejecutar" deletable="false" movable="false" editable="false" x="15" y="15">
+    <statement name="program">
+      <shadow type="required_statement"></shadow>
+      <block type="repetir">
+        <value name="count">
+          <shadow type="required_value"></shadow>
+          <block type="OpAritmetica">
+            <field name="OP">ADD</field>
+            <value name="A">
+              <shadow type="required_value"></shadow>
+              <block type="math_number">
+                <field name="NUM">10</field>
+              </block>
+            </value>
+            <value name="B">
+              <shadow type="required_value"></shadow>
+            </value>
+          </block>
+        </value>
+        <statement name="block">
+          <shadow type="required_statement"></shadow>
+        </statement>
+        <next>
+          <block type="procedures_callnoreturn">
+            <mutation name="Hacer algo2"></mutation>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `, `
+  <block type="procedures_defnoreturn" x="385" y="21">
+    <mutation>
+      <arg name="parámetro 1"></arg>
+    </mutation>
+    <field name="NAME">Hacer algo</field>
+    <field name="ARG0">parámetro 1</field>
+    <statement name="STACK">
+      <block type="DibujarLado">
+        <value name="longitud">
+          <shadow type="required_value"></shadow>
+        </value>
+        <next>
+          <block type="procedures_callnoreturn">
+            <mutation name="Hacer algo">
+              <arg name="parámetro 1"></arg>
+            </mutation>
+            <value name="ARG0">
+              <shadow type="required_value"></shadow>
+            </value>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `, `
+  <block type="procedures_defnoreturn" x="709" y="10">
+    <field name="NAME">Hacer algo2</field>
+    <statement name="STACK">
+      <block type="GirarGrados">
+        <value name="grados">
+          <shadow type="required_value"></shadow>
+          <block type="variables_get" disabled="true">
+            <mutation var="parámetro 1" parent="hZ6TYHUC~Lmbq+5encV["></mutation>
+          </block>
+        </value>
+        <next>
+          <block type="SiNo" disabled="true" x="394" y="141">
+            <value name="condition">
+              <shadow type="required_value"></shadow>
+            </value>
+            <statement name="block1">
+              <shadow type="required_statement"></shadow>
+            </statement>
+            <statement name="block2">
+              <shadow type="required_statement"></shadow>
+            </statement>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `, `
+  <block type="variables_get" disabled="true" x="358" y="216">
+    <mutation var="parámetro 1" parent="hZ6TYHUC~Lmbq+5encV["></mutation>
+  </block>
+  `, `
+  <block type="math_number" disabled="true" x="609" y="218">
+    <field name="NUM">100</field>
+  </block>
+  `, `
+  <block type="SaltarHaciaAdelante" disabled="true" x="156" y="292">
+    <value name="longitud">
+      <shadow type="required_value"></shadow>
+    </value>
+  </block>
+  `]
+  mulangParseWorkspaceTest(`errors`, evilSolution, [
+    entryPoint('al_empezar_a_ejecutar',
+      repeat(application('ADD', number(10), none()), none()),
+      application('Hacer algo2')
+    ),
+    procedure('Hacer algo', ['parámetro 1'],
+      application('DibujarLado', none()),
+      application('Hacer algo', none())
+    ),
+    procedure('Hacer algo2', [],
+      application('GirarGrados', reference('parámetro 1')),
+      ifElse(none(), none(), none())
+    ),
+    reference('parámetro 1'),
+    number(100),
+    application('SaltarHaciaAdelante', none())
+  ])
+
+  const completeSolution = [`
+  <block type="al_empezar_a_ejecutar" id="1" deletable="false" movable="false" editable="false" x="0" y="0">
+    <statement name="program">
+      <block type="procedures_callnoreturn" id="46">
+        <mutation name="Prender compus hacia">
+          <arg name="direccion"></arg>
+        </mutation>
+        <value name="ARG0">
+          <block type="ParaLaDerecha" id="61"></block>
+        </value>
+        <next>
+          <block type="procedures_callnoreturn" id="64">
+            <mutation name="Prender compus hacia">
+              <arg name="direccion"></arg>
+            </mutation>
+            <value name="ARG0">
+              <block type="ParaAbajo" id="72"></block>
+            </value>
+            <next>
+              <block type="procedures_callnoreturn" id="77">
+                <mutation name="Prender compus hacia">
+                  <arg name="direccion"></arg>
+                </mutation>
+                <value name="ARG0">
+                  <block type="ParaLaIzquierda" id="83"></block>
+                </value>
+                <next>
+                  <block type="procedures_callnoreturn" id="92">
+                    <mutation name="Prender compus hacia">
+                      <arg name="direccion"></arg>
+                    </mutation>
+                    <value name="ARG0">
+                      <block type="ParaArriba" id="89"></block>
+                    </value>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `, `
+  <block type="procedures_defnoreturn" id="18" x="7" y="207">
+    <mutation>
+      <arg name="direccion"></arg>
+    </mutation>
+    <field name="NAME">Prender compus hacia</field>
+    <comment pinned="false" h="80" w="160">Describe esta función...</comment>
+    <statement name="STACK">
+      <block type="MoverA" id="95">
+        <value name="direccion">
+          <block type="param_get" id="99">
+            <field name="VAR">direccion</field>
+          </block>
+        </value>
+        <next>
+          <block type="hasta" id="29">
+            <value name="condition">
+              <block type="EstoyEnEsquina" id="31"></block>
+            </value>
+            <statement name="block">
+              <block type="PrenderComputadora" id="41">
+                <next>
+                  <block type="MoverA" id="34">
+                    <value name="direccion">
+                      <block type="param_get" id="38">
+                        <field name="VAR">direccion</field>
+                      </block>
+                    </value>
+                  </block>
+                </next>
+              </block>
+            </statement>
+            <next>
+              <block type="procedures_callnoreturn">
+                <mutation name="Hacer algo"></mutation>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </statement>
+  </block>
+  `, `
+  <block type="procedures_defnoreturn" x="168" y="252">
+    <field name="NAME">Hacer algo</field>
+    <statement name="STACK">
+      <block type="repetir">
+        <value name="count">
+          <shadow type="required_value"></shadow>
+          <block type="math_number">
+            <field name="NUM">10</field>
+          </block>
+        </value>
+        <statement name="block">
+          <shadow type="required_statement"></shadow>
+          <block type="SiNo">
+            <value name="condition">
+              <shadow type="required_value"></shadow>
+              <block type="TocandoBanana"></block>
+            </value>
+            <statement name="block1">
+              <shadow type="required_statement"></shadow>
+              <block type="ComerBanana"></block>
+            </statement>
+            <statement name="block2">
+              <shadow type="required_statement"></shadow>
+              <block type="ComerManzana"></block>
+            </statement>
+          </block>
+        </statement>
+      </block>
+    </statement>
+  </block>
+  `]
+  mulangParseWorkspaceTest(`complete solution`, completeSolution, [
+    entryPoint('al_empezar_a_ejecutar',
+      application('Prender compus hacia', application('ParaLaDerecha')),
+      application('Prender compus hacia', application('ParaAbajo')),
+      application('Prender compus hacia', application('ParaLaIzquierda')),
+      application('Prender compus hacia', application('ParaArriba')),
+    ),
+    procedure('Prender compus hacia', ['direccion'],
+      application('MoverA', reference('direccion')),
+      muUntil(application('EstoyEnEsquina'),
+        application('PrenderComputadora'),
+        application('MoverA', reference('direccion')),
+      ),
+      application('Hacer algo'),
+    ),
+    procedure('Hacer algo', [],
+      repeat(number(10),
+        ifElse(application('TocandoBanana'),
+          application('ComerBanana'),
+          application('ComerManzana')
+        )
+      )
+    )
+  ])
+
+})


### PR DESCRIPTION
resolves https://github.com/Program-AR/pilas-bloques-app/issues/372

Creo que con esto estamos!!!

* Arreglé un bug que había de que no se estaba tomando bien la longitud del programa. La culpa la tenían los sensores (por ejemplo el "hay obstaculo" del 1038). Se parseaban diferente en Ember (en app se parseaban como `Reference` y no era correcto, por eso no los contaba)
* Estabamos manteniendo el scoreable y el control_group del experimento. Por eso el feedback no se mostraba igual que en Ember. Ember usa scoreable y app usaba control group. Decidí ir por scoreable porque da más info.
* Arreglé unos temas que había con las burbujas de sugerencias:
  * No se mostraban todas las que debían porque en el `find` del `EndChallengeDialog` se estaban descartando los casos fallidos si había un sólo caso de éxito.
  * Las sugerencias anidadas quedaban en el bloque de "Al empezar a ejecutar". Faltaba traerse `getNestedControlStructureBlocks` de Ember.
  * No se activaba la lectura simple en las burbujas.
* Migré los tests de mulang!!!!! Por eso quedó tan largo el PR. 