### PR TITLE
Reemplazo de rutas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,17 +61,17 @@ const router = createHashRouter([{
   },
   {
     path: "/desafio/:id",
+    element: <ChallengeView/>,
+    errorElement: <PBError />
+  },
+  {
+    path: "/desafioEmber/:id",
     element: <ChallengeById/>,
     errorElement: <PBError />,
     loader: async() => {
       await PBSession.saveUserIP()
       return null
     }
-  },
-  {
-    path: "/desafioNuevo/:id",
-    element: <ChallengeView/>,
-    errorElement: <PBError />
   },
   {
     path: "/desafios/:challengeName",
@@ -114,11 +114,11 @@ const router = createHashRouter([{
   },
   {
     path: "/creador/ver",
-    element: <EmberCreatorViewMode/>
+    element: <CreatorViewMode/>
   },
   {
-    path: "/creador/verNuevo",
-    element: <CreatorViewMode/>
+    path: "/creador/verEmber",
+    element: <EmberCreatorViewMode/>
   },
   {
     path: "*",

--- a/src/components/EmberChallengeView.tsx
+++ b/src/components/EmberChallengeView.tsx
@@ -5,7 +5,8 @@ import { Header } from "./header/Header";
 import { ChallengeBreadcrumb } from "./challengeView/ChallengeBreadcrumb";
 
 type EmberChallengeViewProps = {
-    challengeId: number
+    challengeId: number,
+    reactPath?: string
 }
 
 // Queda para los desafios hasta tanto tengamos funcional el ChallengeView en React 
@@ -20,14 +21,15 @@ const EmberChallengeView = (props: EmberChallengeViewProps) => {
 
     return <>
         <Header CenterComponent={ChallengeBreadcrumb(path)} shouldShowSimpleReadSwitch={!path.book.simpleReadMode} />
-        <EmberView path={`desafio/${props.challengeId}${solutionParam}`} />
+        <EmberView path={`desafio/${props.challengeId}${solutionParam}`} reactPath={props.reactPath} />
     </>
 }
 
 
 export const ChallengeById = () => {
     var { id } = useParams()
-    return <EmberChallengeView challengeId={currentIdFor(Number(id))} />
+    const challengeId = currentIdFor(Number(id))
+    return <EmberChallengeView challengeId={challengeId} reactPath={`/desafioEmber/${id}`} />
 }
 
 export const ChallengeByName = () => {

--- a/src/components/ImportedChallengeView.tsx
+++ b/src/components/ImportedChallengeView.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import { EmberView } from "./emberView/EmberView";
+import { ChallengeView } from "./challengeView/ChallengeView";
 import { Header } from "./header/Header";
 import { SerializedChallenge } from "./serializedChallenge";
 import { Typography } from "@mui/material";
@@ -13,7 +13,7 @@ export const ImportedChallengeView = () => {
 
     return <>
         <Header CenterComponent={<ImportedChallengeViewBreadcrumb />} />
-        <EmberView path={EMBER_IMPORTED_CHALLENGE_PATH} />
+        <ChallengeView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH} />
     </>
 }
 

--- a/src/components/ImportedChallengeView.tsx
+++ b/src/components/ImportedChallengeView.tsx
@@ -10,19 +10,18 @@ export const EMBER_IMPORTED_CHALLENGE_PATH = "desafio/react-imported-challenge"
 
 
 export const ImportedChallengeView = () => {
+    const location = useLocation();
+    const importedChallenge: SerializedChallenge | undefined = location.state;
 
     return <>
-        <Header CenterComponent={<ImportedChallengeViewBreadcrumb />} />
-        <ChallengeView height='calc(100% - var(--creator-subheader-height))' path={EMBER_IMPORTED_CHALLENGE_PATH} />
+        <Header CenterComponent={<ImportedChallengeViewBreadcrumb importedChallenge={importedChallenge} />} />
+        <ChallengeView path={EMBER_IMPORTED_CHALLENGE_PATH} serializedChallenge={importedChallenge} />
     </>
 }
 
-const ImportedChallengeViewBreadcrumb = () => {
+const ImportedChallengeViewBreadcrumb = ({ importedChallenge }: { importedChallenge: SerializedChallenge | undefined }) => {
 
     const { t } = useTranslation("creator")
-
-    const location = useLocation();
-    const importedChallenge: SerializedChallenge | undefined = location.state;
 
     if (!importedChallenge) throw new Error("No hay desafio importado :(")
 

--- a/src/components/challengeView/ChallengeView.tsx
+++ b/src/components/challengeView/ChallengeView.tsx
@@ -1,4 +1,4 @@
-import { useParams, useLocation } from "react-router-dom"
+import { useParams } from "react-router-dom"
 import { Challenge, PathToChallenge, currentIdFor, getPathToChallenge, shouldShowMultipleScenariosButton } from "../../staticData/challenges";
 import { Collapse, IconButton, PaperProps, Stack } from "@mui/material";
 import MenuIcon from '@mui/icons-material/Menu';
@@ -32,38 +32,37 @@ export const serializedSceneToDescriptor = (scene: Scene) => {
 type ChallengeViewProps = {
   path?: string,
   height?: string,
+  serializedChallenge?: SerializedChallenge | null,
 }
 
-export const ChallengeView = ({ path, height }: ChallengeViewProps) => {
+export const ChallengeView = ({ path, height, serializedChallenge }: ChallengeViewProps) => {
   var { id } = useParams()
   const { theme } = useThemeContext()
-  const location = useLocation()
 
   // TODO Es necesario traerse en challenges.json los statement.decription y statement.clue con sus traducciones para cada desafio
   const { t } = useTranslation('challenges')
 
   const impChallenge: boolean = !!path?.includes("react-imported-challenge")
 
-  const serializedChallengeToChallenge = (serializedChallenge: SerializedChallenge): Challenge => (
+  const serializedChallengeToChallenge = (sc: SerializedChallenge): Challenge => (
     {
-      sceneDescriptor: serializedSceneToDescriptor(serializedChallenge.scene),
-      toolboxBlockIds: serializedChallenge.toolbox.blocks,
-      toolboxStyle: serializedChallenge.toolbox.categorized ? 'categorized' : 'noCategories',
-      debugging: serializedChallenge.stepByStep,
-      predefinedSolution: serializedChallenge.predefinedSolution,
-      shouldShowMultipleScenarioHelp: (serializedChallenge.scene.maps.length > 1),
+      sceneDescriptor: serializedSceneToDescriptor(sc.scene),
+      toolboxBlockIds: sc.toolbox.blocks,
+      toolboxStyle: sc.toolbox.categorized ? 'categorized' : 'noCategories',
+      debugging: sc.stepByStep,
+      predefinedSolution: sc.predefinedSolution,
+      shouldShowMultipleScenarioHelp: (sc.scene.maps.length > 1),
       id: 0,
-      imageURL: () => `imagenes/sceneImages/${serializedChallenge.scene.type}/tool.png`
+      imageURL: () => `imagenes/sceneImages/${sc.scene.type}/tool.png`
     }
   )
 
   const pathToChallenge: PathToChallenge | null = !impChallenge ? getPathToChallenge(currentIdFor(Number(id))) : null
 
-  // For imported challenges, the SerializedChallenge is passed via router state
-  // (navigate("/desafioImportado", {state: challenge})). Fall back to LocalStorage
-  // for the creator's preview flow (/creador/ver) which doesn't use router state.
+  // serializedChallenge prop takes priority (e.g. ImportedChallengeView passes location.state).
+  // Fall back to LocalStorage for the creator's preview flow (/creador/ver).
   const importedSerializedChallenge: SerializedChallenge | null =
-    (location.state as SerializedChallenge | null) ?? LocalStorage.getCreatorChallenge()
+    serializedChallenge !== undefined ? serializedChallenge : LocalStorage.getCreatorChallenge()
 
   const challengeIdentifier = impChallenge ? importedSerializedChallenge?.title : id;
 

--- a/src/components/challengeView/ChallengeView.tsx
+++ b/src/components/challengeView/ChallengeView.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom"
+import { useParams, useLocation } from "react-router-dom"
 import { Challenge, PathToChallenge, currentIdFor, getPathToChallenge, shouldShowMultipleScenariosButton } from "../../staticData/challenges";
 import { Collapse, IconButton, PaperProps, Stack } from "@mui/material";
 import MenuIcon from '@mui/icons-material/Menu';
@@ -37,6 +37,7 @@ type ChallengeViewProps = {
 export const ChallengeView = ({ path, height }: ChallengeViewProps) => {
   var { id } = useParams()
   const { theme } = useThemeContext()
+  const location = useLocation()
 
   // TODO Es necesario traerse en challenges.json los statement.decription y statement.clue con sus traducciones para cada desafio
   const { t } = useTranslation('challenges')
@@ -58,12 +59,18 @@ export const ChallengeView = ({ path, height }: ChallengeViewProps) => {
 
   const pathToChallenge: PathToChallenge | null = !impChallenge ? getPathToChallenge(currentIdFor(Number(id))) : null
 
-  const challengeIdentifier = impChallenge ? LocalStorage.getCreatorChallenge()?.title : id;
+  // For imported challenges, the SerializedChallenge is passed via router state
+  // (navigate("/desafioImportado", {state: challenge})). Fall back to LocalStorage
+  // for the creator's preview flow (/creador/ver) which doesn't use router state.
+  const importedSerializedChallenge: SerializedChallenge | null =
+    (location.state as SerializedChallenge | null) ?? LocalStorage.getCreatorChallenge()
+
+  const challengeIdentifier = impChallenge ? importedSerializedChallenge?.title : id;
 
   const workspace: ChallengeWorkspaceProps = {
-    challenge: (impChallenge ? serializedChallengeToChallenge(LocalStorage.getCreatorChallenge()!) : pathToChallenge!.challenge),
-    statement: impChallenge ? LocalStorage.getCreatorChallenge()!.statement.description : t(`${id}.statement`)!,
-    clue: impChallenge ? LocalStorage.getCreatorChallenge()!.statement.clue || '' : t(`${id}.clue`)!,
+    challenge: (impChallenge ? serializedChallengeToChallenge(importedSerializedChallenge!) : pathToChallenge!.challenge),
+    statement: impChallenge ? importedSerializedChallenge!.statement.description : t(`${id}.statement`)!,
+    clue: impChallenge ? importedSerializedChallenge!.statement.clue || '' : t(`${id}.clue`)!,
     challengeIdentifier
   }
 

--- a/src/components/creator/Editor/ActionButtons/EmberPreviewButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/EmberPreviewButton.tsx
@@ -4,7 +4,7 @@ import { Visibility } from "@mui/icons-material";
 
 export const EmberPreviewButton = () => {
 
-    return <Link to="/creador/ver">
+    return <Link to="/creador/verEmber">
             <StyledCreatorActionButton startIcon={<Visibility/>} nametag='oldPreview'/>
         </Link>
 

--- a/src/components/creator/Editor/ActionButtons/PreviewButton.tsx
+++ b/src/components/creator/Editor/ActionButtons/PreviewButton.tsx
@@ -4,7 +4,7 @@ import { Visibility } from "@mui/icons-material";
 
 export const PreviewButton = () => {
 
-    return <Link to="/creador/verNuevo">
+    return <Link to="/creador/ver">
             <StyledCreatorActionButton startIcon={<Visibility/>} nametag='preview'/>
         </Link>
 

--- a/src/components/emberView/EmberView.tsx
+++ b/src/components/emberView/EmberView.tsx
@@ -7,7 +7,8 @@ import { PBProgress } from "../PBProgress";
 
 type EmberViewProps = {
     path: string,
-    height?: string
+    height?: string,
+    reactPath?: string
 }
 
 export const EmberView = (props: EmberViewProps) => {
@@ -20,9 +21,11 @@ export const EmberView = (props: EmberViewProps) => {
 
     const handleMessage = useCallback((event: MessageEvent)=>{
         if (event.source === iframeRef.current?.contentWindow && event.data && event.data.route) {
-            navigate(event.data.route.slice(1)) //routes always start with #, the slice is to remove it
+            // If a reactPath is provided, use it instead of Ember's internal route
+            // to avoid overwriting the current URL (e.g. /desafioEmber -> /desafio)
+            navigate(props.reactPath ?? event.data.route.slice(1)) //routes always start with #, the slice is to remove it
         }
-    },[navigate])
+    },[navigate, props.reactPath])
     
     useEffect(() => {
         window.addEventListener('message', handleMessage)


### PR DESCRIPTION
resolves https://github.com/Program-AR/pilas-bloques-app/issues/318

* Se reemplazaron las rutas de `desafioNuevo` y `verNuevo` por `desafio` y `ver`, así el default siempre es la `ChallengeView`. 
* Se mantiene la `EmberView` en `desafioEmber` y `verEmber`. Para mantenerlo hubo que agregar `reactPath` para que no redirigiera a la `ChallengeView`.
* El `ImportedChallengeView` leía el desafío del local storage del creador en vez del archivo que se había subido, generando inconsistencias. Por eso ahora `ChallengeView` primero lee de location.state (el desafío importado, por ejemplo) y si no encuentra nada, va al local storage (para el flujo del creador/ver). El `useLocation` tiene que estar en `ImportedChallengeView` para que `ChallengeView` no depende del router y pueda ser montado por los test de cypress
