### PR TITLE
Agregando prefijo para las sugerencias

### DIFF
--- a/src/components/blockly/mulang/expectationMessages.ts
+++ b/src/components/blockly/mulang/expectationMessages.ts
@@ -5,8 +5,8 @@ export const messageForExpectation = (
   result: MulangExpectationResult,
   t: TFunction
 ) => {
-  return t(`suggestions.${result.id}`, {
+  return ` -  ${t(`suggestions.${result.id}`, {
     ns: 'mulang',
     defaultValue: t('suggestions.check_out_this_block', { ns: 'mulang' }),
-  })
+  })}`
 }


### PR DESCRIPTION
Resolves #386 
Cambié la función `messageForExpectation` para devolver una cadena formateada con un prefijo de viñeta (`-`) en lugar de retornar directamente la llamada a la traducción `t(...)`.
Antes:
<img width="1865" height="683" alt="Captura de pantalla de 2026-08-12 18-57-41" src="https://github.com/user-attachments/assets/399bc9a5-39c1-4147-a350-8cfe828da2ba" />

Despues:
<img width="1858" height="702" alt="Captura de pantalla de 2026-08-12 18-55-55" src="https://github.com/user-attachments/assets/7af91ac2-fb47-4bef-a282-505a06458ce9" />

